### PR TITLE
Throw an error when the user is not found

### DIFF
--- a/StellarWallet.Application/Services/AuthService.cs
+++ b/StellarWallet.Application/Services/AuthService.cs
@@ -12,8 +12,7 @@ namespace StellarWallet.Application.Services
 
         public async Task<LoggedDto> Login(LoginDto loginDto)
         {
-            User user = await _userRepository.GetBy("Email", loginDto.Email);
-
+            User? user = await _userRepository.GetBy("Email", loginDto.Email) ?? throw new Exception("User not found");
             if (user.Password != loginDto.Password)
                 throw new Exception("Invalid password");
 


### PR DESCRIPTION
# Summary

- Throw an error when the user is not found.

# Details

- The API will now send the correct error when the user's email sent for login does not exist in the database.