### PR TITLE
refactor: payment

### DIFF
--- a/StellarWallet.Application/Dtos/Requests/SendPaymentDto.cs
+++ b/StellarWallet.Application/Dtos/Requests/SendPaymentDto.cs
@@ -2,10 +2,10 @@
 
 namespace StellarWallet.Application.Dtos.Requests
 {
-    public class SendPaymentDto(int userId, string destinationPublicKey, decimal amount)
+    public class SendPaymentDto(string userToken, string destinationPublicKey, decimal amount)
     {
-        [Range(1, int.MaxValue, ErrorMessage = "Invalid user ID")]
-        public int UserId { get; set; } = userId;
+        [Required(ErrorMessage = "User token is required")]
+        public string UserToken { get; set; } = userToken;
 
         [Required(ErrorMessage = "Public key is required")]
         [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]

--- a/StellarWallet.Application/Interfaces/IJwtService.cs
+++ b/StellarWallet.Application/Interfaces/IJwtService.cs
@@ -6,5 +6,6 @@ namespace StellarWallet.Application.Interfaces
     public interface IJwtService
     {
         string CreateToken(string email);
+        string DecodeToken(string token);
     }
 }

--- a/StellarWallet.Application/Services/JwtService.cs
+++ b/StellarWallet.Application/Services/JwtService.cs
@@ -32,5 +32,37 @@ namespace StellarWallet.Application.Services
 
             return tokenHandler.WriteToken(tokenConfig);
         }
+
+        public string DecodeToken(string token)
+        {
+            var tokenHandler = new JwtSecurityTokenHandler();
+
+            if (secretKey == null)
+                throw new Exception("Secret key not found");
+            var keyBytes = Encoding.ASCII.GetBytes(secretKey);
+
+            var validationParameters = new TokenValidationParameters
+            {
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(keyBytes),
+                ValidateIssuer = false,
+                ValidateAudience = false
+            };
+
+            try
+            {
+                var claimsPrincipal = tokenHandler.ValidateToken(token, validationParameters, out _);
+
+                var allClaims = claimsPrincipal.Claims.ToList();
+
+                if(allClaims.Count == 0)
+                    throw new Exception("No claims found");
+                return allClaims[0].Value;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error decoding JWT: {ex.Message}");
+            }
+        }
     }
 }


### PR DESCRIPTION
# Summary

- Add the `DecodeToken` method to the `JwtService` class and its interface `IJwtService`.
- Add the `UserToken` attribute to the `SendPaymentDto` class.
- Use the `DecodeToken` method in the `SendPayment` method of the `TransactionService` class.

# Details

- The API now requires the user token for authentication purposes when sending a payment.