### PR TITLE
ref: user service

### DIFF
--- a/StellarWallet.Infrastructure/appsettings.Development.json
+++ b/StellarWallet.Infrastructure/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "StellarWallet": "Data Source=MatiDev\\MSSQLSERVER03;Initial Catalog=Wallet;Integrated Security=True;Pooling=False;Encrypt=False;Trust Server Certificate=False"
+    "StellarWalletDatabase": "Data Source=MatiDev\\MSSQLSERVER03;Initial Catalog=Wallet;Integrated Security=True;Pooling=False;Encrypt=False;Trust Server Certificate=False"
   },
   "Stellar": {
     "HorizonUrl": "https://horizon-testnet.stellar.org",

--- a/StellarWallet.Infrastructure/appsettings.test.json
+++ b/StellarWallet.Infrastructure/appsettings.test.json
@@ -1,7 +1,7 @@
 {
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "StellarWallet": "Data Source=MatiDev\\MSSQLSERVER03;Initial Catalog=Wallet_Tests;Integrated Security=True;Pooling=False;Encrypt=False;Trust Server Certificate=False"
+    "StellarWalletDatabase": "Data Source=MatiDev\\MSSQLSERVER03;Initial Catalog=Wallet_Tests;Integrated Security=True;Pooling=False;Encrypt=False;Trust Server Certificate=False"
   },
   "Stellar": {
     "HorizonUrl": "https://horizon-testnet.stellar.org",

--- a/StellarWallet.WebApi/appsettings.Development.json
+++ b/StellarWallet.WebApi/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "StellarWallet": "Data Source=MatiDev\\MSSQLSERVER03;Initial Catalog=Wallet;Integrated Security=True;Pooling=False;Encrypt=False;Trust Server Certificate=False"
+    "StellarWalletDatabase": "Data Source=MatiDev\\MSSQLSERVER03;Initial Catalog=Wallet;Integrated Security=True;Pooling=False;Encrypt=False;Trust Server Certificate=False"
   },
   "Stellar": {
     "HorizonUrl": "https://horizon-testnet.stellar.org",

--- a/StellarWallet.WebApi/appsettings.json.example
+++ b/StellarWallet.WebApi/appsettings.json.example
@@ -1,7 +1,7 @@
 {
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "StellarWallet": "Server=(localdb)\\CFServer;Database=StellarWallet;"
+    "StellarWalletDatabase": "Server=(localdb)\\CFServer;Database=StellarWallet;"
   },
   "Stellar": {
     "HorizonUrl": "https://horizon-testnet.stellar.org",


### PR DESCRIPTION
# Summary

- Replace use of `_userRepository` with `_unitOfWork` in `UserService`.
- Update the configuration `JSON` files in the infrastructure and `API` layers.

# Details

- Now the user service uses the UnitOfWork instead of the user repository.