### PR TITLE
ref: database context namespace

### DIFF
--- a/StellarWallet.Infrastructure/DatabaseContext.cs
+++ b/StellarWallet.Infrastructure/DatabaseContext.cs
@@ -2,7 +2,7 @@
 using StellarWallet.Domain.Entities;
 using System.Reflection;
 
-namespace StellarWallet.Infrastructure.DatabaseConnection
+namespace StellarWallet.Infrastructure
 {
     public class DatabaseContext : DbContext
     {

--- a/StellarWallet.Infrastructure/Migrations/20240511011131_InitialMigration.Designer.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240511011131_InitialMigration.Designer.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using StellarWallet.Infrastructure.DatabaseConnection;
+using StellarWallet.Infrastructure;
 
 #nullable disable
 

--- a/StellarWallet.Infrastructure/Migrations/20240511040127_UserContactsUpdate.Designer.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240511040127_UserContactsUpdate.Designer.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using StellarWallet.Infrastructure.DatabaseConnection;
+using StellarWallet.Infrastructure;
 
 #nullable disable
 

--- a/StellarWallet.Infrastructure/Migrations/20240511204834_UserContactNewPK.Designer.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240511204834_UserContactNewPK.Designer.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using StellarWallet.Infrastructure.DatabaseConnection;
+using StellarWallet.Infrastructure;
 
 #nullable disable
 

--- a/StellarWallet.Infrastructure/Migrations/20240512143050_AddPublicKeyToUserContact.Designer.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240512143050_AddPublicKeyToUserContact.Designer.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using StellarWallet.Infrastructure.DatabaseConnection;
+using StellarWallet.Infrastructure;
 
 #nullable disable
 

--- a/StellarWallet.Infrastructure/Migrations/20240512143354_UpdatePublicKeyInUserContact.Designer.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240512143354_UpdatePublicKeyInUserContact.Designer.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using StellarWallet.Infrastructure.DatabaseConnection;
+using StellarWallet.Infrastructure;
 
 #nullable disable
 

--- a/StellarWallet.Infrastructure/Migrations/20240512230338_AddRoleInUser.Designer.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240512230338_AddRoleInUser.Designer.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using StellarWallet.Infrastructure.DatabaseConnection;
+using StellarWallet.Infrastructure;
 
 #nullable disable
 

--- a/StellarWallet.Infrastructure/Migrations/20240801233509_UpdateEntitiesRelations.Designer.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240801233509_UpdateEntitiesRelations.Designer.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using StellarWallet.Infrastructure.DatabaseConnection;
+using StellarWallet.Infrastructure;
 
 #nullable disable
 

--- a/StellarWallet.Infrastructure/Migrations/DatabaseContextModelSnapshot.cs
+++ b/StellarWallet.Infrastructure/Migrations/DatabaseContextModelSnapshot.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using StellarWallet.Infrastructure.DatabaseConnection;
+using StellarWallet.Infrastructure;
 
 #nullable disable
 

--- a/StellarWallet.Infrastructure/Repositories/BlockchainAccountRepository.cs
+++ b/StellarWallet.Infrastructure/Repositories/BlockchainAccountRepository.cs
@@ -1,6 +1,5 @@
 ﻿using StellarWallet.Domain.Entities;
 using StellarWallet.Domain.Interfaces.Persistence;
-using StellarWallet.Infrastructure.DatabaseConnection;
 
 namespace StellarWallet.Infrastructure.Repositories
 {

--- a/StellarWallet.Infrastructure/Repositories/Repository.cs
+++ b/StellarWallet.Infrastructure/Repositories/Repository.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using StellarWallet.Domain.Interfaces.Persistence;
-using StellarWallet.Infrastructure.DatabaseConnection;
 using System.Linq.Expressions;
 
 namespace StellarWallet.Infrastructure.Repositories

--- a/StellarWallet.Infrastructure/Repositories/UnitOfWork.cs
+++ b/StellarWallet.Infrastructure/Repositories/UnitOfWork.cs
@@ -1,5 +1,4 @@
 ﻿using StellarWallet.Domain.Interfaces.Persistence;
-using StellarWallet.Infrastructure.DatabaseConnection;
 
 namespace StellarWallet.Infrastructure.Repositories
 {

--- a/StellarWallet.Infrastructure/Repositories/UserContactRepository.cs
+++ b/StellarWallet.Infrastructure/Repositories/UserContactRepository.cs
@@ -1,7 +1,5 @@
 ﻿using StellarWallet.Domain.Entities;
 using StellarWallet.Domain.Interfaces.Persistence;
-using StellarWallet.Infrastructure.DatabaseConnection;
-
 
 namespace StellarWallet.Infrastructure.Repositories
 {

--- a/StellarWallet.Infrastructure/Repositories/UserRepository.cs
+++ b/StellarWallet.Infrastructure/Repositories/UserRepository.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using StellarWallet.Domain.Entities;
 using StellarWallet.Domain.Interfaces.Persistence;
-using StellarWallet.Infrastructure.DatabaseConnection;
 
 namespace StellarWallet.Infrastructure.Repositories
 {

--- a/StellarWallet.IntegrationTest/StellarWalletWebApplicationFactory.cs
+++ b/StellarWallet.IntegrationTest/StellarWalletWebApplicationFactory.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using StellarWallet.Infrastructure.DatabaseConnection;
+using StellarWallet.Infrastructure;
 
 namespace StellarWallet.IntegrationTest
 {

--- a/StellarWallet.WebApi/Program.cs
+++ b/StellarWallet.WebApi/Program.cs
@@ -6,7 +6,7 @@ using StellarWallet.Application.Mappers;
 using StellarWallet.Application.Services;
 using StellarWallet.Domain.Interfaces.Persistence;
 using StellarWallet.Domain.Interfaces.Services;
-using StellarWallet.Infrastructure.DatabaseConnection;
+using StellarWallet.Infrastructure;
 using StellarWallet.Infrastructure.Repositories;
 using StellarWallet.Infrastructure.Stellar;
 using System.Security.Claims;


### PR DESCRIPTION
# Summary

- Rename the `namespace` of the `database context` to `StellarWallet.Infrastructure`.
- Update the `using` statements to match the new `namespace` value.

# Details

- Rename the namespace of the database context to match the folder structure.