### PR TITLE
ref: result pattern use

### DIFF
--- a/StellarWallet.Application/Interfaces/IAuthService.cs
+++ b/StellarWallet.Application/Interfaces/IAuthService.cs
@@ -1,12 +1,14 @@
 ﻿using StellarWallet.Application.Dtos.Requests;
 using StellarWallet.Application.Dtos.Responses;
+using StellarWallet.Domain.Errors;
+using StellarWallet.Domain.Result;
 
 namespace StellarWallet.Application.Interfaces
 {
     public interface IAuthService
     {
-        Task<LoggedDto> Login(LoginDto loginDto);
-        bool AuthenticateEmail(string jwt, string email);
-        Task<bool> AuthenticateToken(string jwt);
+        Task<Result<LoggedDto, DomainError>> Login(LoginDto loginDto);
+        Result<bool, DomainError> AuthenticateEmail(string jwt, string email);
+        Task<Result<bool, DomainError>> AuthenticateToken(string jwt);
     }
 }

--- a/StellarWallet.Application/Interfaces/ITransactionService.cs
+++ b/StellarWallet.Application/Interfaces/ITransactionService.cs
@@ -1,16 +1,18 @@
 ﻿using StellarWallet.Application.Dtos.Requests;
 using StellarWallet.Application.Dtos.Responses;
 using StellarWallet.Domain.Entities;
+using StellarWallet.Domain.Errors;
+using StellarWallet.Domain.Result;
 using StellarWallet.Domain.Structs;
 
 namespace StellarWallet.Application.Interfaces
 {
     public interface ITransactionService
     {
-        public Task<BlockchainAccount> CreateAccount(string jwt);
-        public Task<bool> SendPayment(SendPaymentDto sendPaymentDto, string jwt);
-        public Task<BlockchainPayment[]> GetTransaction(string jwt, int pageNumber, int pageSize);
-        public Task<bool> GetTestFunds(string publicKey);
-        public Task<FoundBalancesDto> GetBalances(GetBalancesDto publicKey);
+        public Task<Result<BlockchainAccount, DomainError>> CreateAccount(string jwt);
+        public Task<Result<bool, DomainError>> SendPayment(SendPaymentDto sendPaymentDto, string jwt);
+        public Task<Result<BlockchainPayment[], DomainError>> GetTransaction(string jwt, int pageNumber, int pageSize);
+        public Task<Result<bool, DomainError>> GetTestFunds(string publicKey);
+        public Task<Result<FoundBalancesDto, DomainError>> GetBalances(GetBalancesDto publicKey);
     }
 }

--- a/StellarWallet.Application/Interfaces/IUserContactService.cs
+++ b/StellarWallet.Application/Interfaces/IUserContactService.cs
@@ -1,13 +1,15 @@
 ﻿using StellarWallet.Application.Dtos.Requests;
 using StellarWallet.Application.Dtos.Responses;
+using StellarWallet.Domain.Errors;
+using StellarWallet.Domain.Result;
 
 namespace StellarWallet.Application.Interfaces
 {
     public interface IUserContactService
     {
-        Task<IEnumerable<UserContactsDto>> GetAll(int id, string jwt);
-        Task Add(AddContactDto userContact, string jwt);
-        Task Update(UpdateContactDto userContact);
-        Task Delete(int id);
+        Task<Result<IEnumerable<UserContactsDto>, DomainError>> GetAll(int id, string jwt);
+        Task<Result<bool, DomainError>> Add(AddContactDto userContact, string jwt);
+        Task<Result<bool, DomainError>> Update(UpdateContactDto userContact);
+        Task<Result<bool, DomainError>> Delete(int id);
     }
 }

--- a/StellarWallet.Application/Interfaces/IUserService.cs
+++ b/StellarWallet.Application/Interfaces/IUserService.cs
@@ -1,15 +1,17 @@
 ﻿using StellarWallet.Application.Dtos.Requests;
 using StellarWallet.Application.Dtos.Responses;
+using StellarWallet.Domain.Errors;
+using StellarWallet.Domain.Result;
 
 namespace StellarWallet.Application.Interfaces
 {
     public interface IUserService
     {
         Task<IEnumerable<UserDto>> GetAll();
-        Task<UserDto> GetById(int id, string jwt);
-        Task<LoggedDto> Add(UserCreationDto user);
-        Task Update(UserUpdateDto user, string jwt);
-        Task Delete(int id, string jwt);
-        Task AddWallet(AddWalletDto wallet, string jwt);
+        Task<Result<UserDto, DomainError>> GetById(int id, string jwt);
+        Task<Result<LoggedDto, DomainError>> Add(UserCreationDto user);
+        Task<Result<bool, DomainError>> Update(UserUpdateDto user, string jwt);
+        Task<Result<bool, DomainError>> Delete(int id, string jwt);
+        Task<Result<bool, DomainError>> AddWallet(AddWalletDto wallet, string jwt);
     }
 }

--- a/StellarWallet.Domain/Errors/DomainError.cs
+++ b/StellarWallet.Domain/Errors/DomainError.cs
@@ -8,5 +8,7 @@
         public static DomainError Invalid(string? errorMessage = "Invalid parameter.") => new(errorMessage, ErrorType.Invalid);
         public static DomainError Conflict(string? errorMessage = "Conflict with existing data.") => new(errorMessage, ErrorType.Conflict);
         public static DomainError ExternalServiceError(string? errorMessage = "External service error.") => new(errorMessage, ErrorType.ExternalServiceError);
+        public static DomainError Unauthorized(string? errorMessage = "Unauthorized access.") => new(errorMessage, ErrorType.UnauthorizedError);
+        public static DomainError InternalError(string? errorMessage = "Internal server error.") => new(errorMessage, ErrorType.InternalError);
     }
 }

--- a/StellarWallet.Domain/Errors/ErrorType.cs
+++ b/StellarWallet.Domain/Errors/ErrorType.cs
@@ -5,6 +5,8 @@
         NotFound,
         Invalid,
         Conflict,
-        ExternalServiceError
+        ExternalServiceError,
+        UnauthorizedError,
+        InternalError
     }
 }

--- a/StellarWallet.Domain/Interfaces/Services/IBlockchainService.cs
+++ b/StellarWallet.Domain/Interfaces/Services/IBlockchainService.cs
@@ -1,5 +1,7 @@
 ﻿using StellarWallet.Domain.Entities;
 using StellarWallet.Domain.Structs;
+using StellarWallet.Domain.Result;
+using StellarWallet.Domain.Errors;
 
 namespace StellarWallet.Domain.Interfaces.Services
 {
@@ -7,9 +9,9 @@ namespace StellarWallet.Domain.Interfaces.Services
     {
         public BlockchainAccount CreateAccount(int userId);
         public AccountKeyPair CreateKeyPair();
-        public Task<bool> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount);
-        public Task<BlockchainPayment[]> GetPayments(string publicKey);
-        public Task<bool> GetTestFunds(string publicKey);
-        public Task<List<AccountBalances>> GetBalances(string publicKey);
+        public Task<Result<bool, DomainError>> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount);
+        public Task<Result<BlockchainPayment[], DomainError>> GetPayments(string publicKey);
+        public Task<Result<bool, DomainError>> GetTestFunds(string publicKey);
+        public Task<Result<List<AccountBalances>, DomainError>> GetBalances(string publicKey);
     }
 }

--- a/StellarWallet.Domain/Interfaces/Services/IJwtService.cs
+++ b/StellarWallet.Domain/Interfaces/Services/IJwtService.cs
@@ -1,8 +1,11 @@
-﻿namespace StellarWallet.Domain.Interfaces.Services
+﻿using StellarWallet.Domain.Errors;
+using StellarWallet.Domain.Result;
+
+namespace StellarWallet.Domain.Interfaces.Services
 {
     public interface IJwtService
     {
-        string CreateToken(string email, string role);
-        string DecodeToken(string token);
+        Result<string, DomainError> CreateToken(string email, string role);
+        Result<string, DomainError> DecodeToken(string token);
     }
 }

--- a/StellarWallet.Domain/Result/Result.cs
+++ b/StellarWallet.Domain/Result/Result.cs
@@ -1,5 +1,6 @@
 ﻿using StellarWallet.Domain.Errors;
 using StellarWallet.Domain.Interfaces.Result;
+using System.Text.Json.Serialization;
 
 namespace StellarWallet.Domain.Result
 {
@@ -9,6 +10,7 @@ namespace StellarWallet.Domain.Result
         public bool IsSuccess { get; }
         public TError Error { get; }
 
+        [JsonConstructor]
         private Result(TValue value, bool isSuccess, TError error)
         {
             Value = value;

--- a/StellarWallet.Infrastructure/Services/JwtService.cs
+++ b/StellarWallet.Infrastructure/Services/JwtService.cs
@@ -1,20 +1,26 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
+using StellarWallet.Domain.Errors;
 using StellarWallet.Domain.Interfaces.Services;
+using StellarWallet.Domain.Result;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
 
-namespace StellarWallet.Application.Services
+namespace StellarWallet.Infrastructure.Services
 {
     public class JwtService(IConfiguration config) : IJwtService
     {
-        private readonly string secretKey = config.GetSection("Jwt").GetSection("Key").Value ?? throw new Exception("Secret key not found");
-        private readonly string issuer = config.GetSection("Jwt").GetSection("Issuer").Value ?? throw new Exception("Issuer not found");
-        private readonly string audience = config.GetSection("Jwt").GetSection("Audience").Value ?? throw new Exception("Audience not found");
+        private readonly string? secretKey = config.GetSection("Jwt").GetSection("Key").Value;
+        private readonly string? issuer = config.GetSection("Jwt").GetSection("Issuer").Value;
+        private readonly string? audience = config.GetSection("Jwt").GetSection("Audience").Value;
 
-        public string CreateToken(string email, string role)
+        public Result<string, DomainError> CreateToken(string email, string role)
         {
+            if (secretKey is null)
+            {
+                return Result<string, DomainError>.Failure(DomainError.NotFound("No secret key found."));
+            }
             var keyBytes = Encoding.ASCII.GetBytes(secretKey);
             var claims = new ClaimsIdentity();
 
@@ -32,15 +38,18 @@ namespace StellarWallet.Application.Services
             var tokenHandler = new JwtSecurityTokenHandler();
             var tokenConfig = tokenHandler.CreateToken(tokenDescriptor);
 
-            return tokenHandler.WriteToken(tokenConfig);
+            return Result<string, DomainError>.Success(tokenHandler.WriteToken(tokenConfig));
         }
 
-        public string DecodeToken(string token)
+        public Result<string, DomainError> DecodeToken(string token)
         {
             var tokenHandler = new JwtSecurityTokenHandler();
 
-            if (secretKey == null)
-                throw new Exception("Secret key not found");
+            if (secretKey is null)
+            {
+                return Result<string, DomainError>.Failure(DomainError.NotFound("No secret key found."));
+            }
+
             var keyBytes = Encoding.ASCII.GetBytes(secretKey);
 
             var validationParameters = new TokenValidationParameters
@@ -51,26 +60,24 @@ namespace StellarWallet.Application.Services
                 ValidateAudience = false
             };
 
-            try
+            var claimsPrincipal = tokenHandler.ValidateToken(token, validationParameters, out _);
+
+            if (claimsPrincipal is null)
             {
-                var claimsPrincipal = tokenHandler.ValidateToken(token, validationParameters, out _);
-
-                var allClaims = claimsPrincipal.Claims.ToList();
-                if (allClaims.Count == 0)
-                    throw new Exception("No claims found");
-
-                var emailClaim = allClaims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier);
-                var roleClaim = allClaims.FirstOrDefault(c => c.Type == ClaimTypes.Role);
-
-                if (emailClaim == null || roleClaim == null)
-                    throw new Exception("Email or role claim not found");
-
-                return emailClaim.Value;
+                return Result<string, DomainError>.Failure(DomainError.NotFound("No claims found."));
             }
-            catch (Exception ex)
+
+            var allClaims = claimsPrincipal.Claims.ToList();
+
+            var emailClaim = allClaims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier);
+            var roleClaim = allClaims.FirstOrDefault(c => c.Type == ClaimTypes.Role);
+
+            if (emailClaim is null || roleClaim is null)
             {
-                throw new Exception($"Error decoding JWT: {ex.Message}");
+                return Result<string, DomainError>.Failure(DomainError.NotFound("Email or role claim not found."));
             }
+
+            return Result<string, DomainError>.Success(emailClaim.Value);
         }
     }
 }

--- a/StellarWallet.IntegrationTest/UserControllerTests.cs
+++ b/StellarWallet.IntegrationTest/UserControllerTests.cs
@@ -1,5 +1,7 @@
 using StellarWallet.Application.Dtos.Requests;
 using StellarWallet.Application.Dtos.Responses;
+using StellarWallet.Domain.Errors;
+using StellarWallet.Domain.Result;
 using System.Net.Http.Json;
 
 namespace StellarWallet.IntegrationTest
@@ -23,11 +25,11 @@ namespace StellarWallet.IntegrationTest
             var response = await client.PostAsJsonAsync("/User", request);
 
             response.EnsureSuccessStatusCode();
-            var createUserResponse = await response.Content.ReadFromJsonAsync<LoggedDto>();
+            var createUserResponse = await response.Content.ReadFromJsonAsync<Result<LoggedDto, DomainError>>();
 
-            Assert.True(createUserResponse?.Success);
-            Assert.Null(createUserResponse?.Token);
-            Assert.NotNull(createUserResponse?.PublicKey);
+            Assert.True(createUserResponse?.Value.Success);
+            Assert.Null(createUserResponse?.Value.Token);
+            Assert.NotNull(createUserResponse?.Value.PublicKey);
         }
     }
 }

--- a/StellarWallet.WebApi/Controllers/TransactionController.cs
+++ b/StellarWallet.WebApi/Controllers/TransactionController.cs
@@ -83,7 +83,9 @@ namespace StellarWallet.WebApi.Controllers
             if (jwt is null)
                 return Unauthorized();
 
-            bool wasFunded = await _transactionService.GetTestFunds(getTestFundsDto.PublicKey);
+            var getFundsResponse = await _transactionService.GetTestFunds(getTestFundsDto.PublicKey);
+
+            bool wasFunded = getFundsResponse.IsSuccess;
 
             if (wasFunded)
                 return Ok();

--- a/StellarWallet.WebApi/Program.cs
+++ b/StellarWallet.WebApi/Program.cs
@@ -6,11 +6,12 @@ using StellarWallet.Application.Mappers;
 using StellarWallet.Application.Services;
 using StellarWallet.Domain.Interfaces.Persistence;
 using StellarWallet.Domain.Interfaces.Services;
-using StellarWallet.Infrastructure;
+using StellarWallet.Infrastructure.Services;
 using StellarWallet.Infrastructure.Repositories;
 using StellarWallet.Infrastructure.Stellar;
 using System.Security.Claims;
 using System.Text;
+using StellarWallet.Infrastructure;
 
 string environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "test";
 


### PR DESCRIPTION
# Summary

- Update `ErrorType` enum and add new methods to the `DomainError` class.
- Add a new `Data Annotation` in the `Result` class for testing purposes.
- Refactor de `JwtService` and `StellarService` classes and its interfaces to use the `Result` pattern.
- Refactor the `Application` layer services and interfaces to use the `Result` pattern.
- Update the `GetTestFunds` method in the `TransactionController` class.
- Update `using` statements in `Program.cs`.
- Update all unit and integration tests based on the refactoring.

# Details

- Apply the Result pattern.