### PR TITLE
fix: namespace names

### DIFF
--- a/StellarWallet.Infrastructure/Services/EncryptionService.cs
+++ b/StellarWallet.Infrastructure/Services/EncryptionService.cs
@@ -1,6 +1,6 @@
 ﻿using StellarWallet.Domain.Interfaces.Services;
 
-namespace StellarWallet.Application.Services
+namespace StellarWallet.Infrastructure.Services
 {
     public class EncryptionService : IEncryptionService
     {

--- a/StellarWallet.Infrastructure/Services/StellarService.cs
+++ b/StellarWallet.Infrastructure/Services/StellarService.cs
@@ -8,7 +8,7 @@ using StellarWallet.Domain.Result;
 using StellarWallet.Domain.Structs;
 using StellarWallet.Infrastructure.Utilities;
 
-namespace StellarWallet.Infrastructure.Stellar
+namespace StellarWallet.Infrastructure.Services
 {
     public class StellarService : IBlockchainService
     {

--- a/StellarWallet.WebApi/Program.cs
+++ b/StellarWallet.WebApi/Program.cs
@@ -8,7 +8,6 @@ using StellarWallet.Domain.Interfaces.Persistence;
 using StellarWallet.Domain.Interfaces.Services;
 using StellarWallet.Infrastructure.Services;
 using StellarWallet.Infrastructure.Repositories;
-using StellarWallet.Infrastructure.Stellar;
 using System.Security.Claims;
 using System.Text;
 using StellarWallet.Infrastructure;


### PR DESCRIPTION
# Summary

- Change `namespace` `StellarWallet.Application.Services` to `StellarWallet.Infrastructure.Services` in `EncryptionService.cs`.
- Change `namespace` `StellarWallet.Application.Stellar` to `StellarWallet.Infrastructure.Services` in `StellarService.cs`.
- Remove duplicated `using` statement in `Program.cs`.

# Details

- Change namespace names in the infrastructure layer to match the folder structure.