### PR TITLE
ref: send payment

### DIFF
--- a/StellarWallet.Application/Dtos/Requests/SendPaymentDto.cs
+++ b/StellarWallet.Application/Dtos/Requests/SendPaymentDto.cs
@@ -2,7 +2,7 @@
 
 namespace StellarWallet.Application.Dtos.Requests
 {
-    public class SendPaymentDto(string destinationPublicKey, decimal amount)
+    public class SendPaymentDto(string destinationPublicKey, decimal amount, string memo)
     {
         [Required(ErrorMessage = "Public key is required")]
         [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
@@ -10,5 +10,8 @@ namespace StellarWallet.Application.Dtos.Requests
 
         [Range(0.0001, double.MaxValue, ErrorMessage = "Invalid amount")]
         public decimal Amount { get; set; } = amount;
+
+        [StringLength(28, MinimumLength = 1, ErrorMessage = "Memo must have between 1 and 28 characters")]
+        public string? Memo { get; set; } = memo;
     }
 }

--- a/StellarWallet.Application/Services/TransactionService.cs
+++ b/StellarWallet.Application/Services/TransactionService.cs
@@ -47,7 +47,7 @@ namespace StellarWallet.Application.Services
                 return Result<bool, DomainError>.Failure(DomainError.Unauthorized("Unauthorized"));
             }
 
-            var transactionResponse = await _blockchainService.SendPayment(user.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString());
+            var transactionResponse = await _blockchainService.SendPayment(user.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), sendPaymentDto.Memo);
 
             bool transactionCompleted = transactionResponse.IsSuccess;
 

--- a/StellarWallet.Domain/Interfaces/Services/IBlockchainService.cs
+++ b/StellarWallet.Domain/Interfaces/Services/IBlockchainService.cs
@@ -1,7 +1,7 @@
 ﻿using StellarWallet.Domain.Entities;
-using StellarWallet.Domain.Structs;
-using StellarWallet.Domain.Result;
 using StellarWallet.Domain.Errors;
+using StellarWallet.Domain.Result;
+using StellarWallet.Domain.Structs;
 
 namespace StellarWallet.Domain.Interfaces.Services
 {
@@ -9,7 +9,7 @@ namespace StellarWallet.Domain.Interfaces.Services
     {
         public BlockchainAccount CreateAccount(int userId);
         public AccountKeyPair CreateKeyPair();
-        public Task<Result<bool, DomainError>> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount);
+        public Task<Result<bool, DomainError>> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount, string memo);
         public Task<Result<BlockchainPayment[], DomainError>> GetPayments(string publicKey);
         public Task<Result<bool, DomainError>> GetTestFunds(string publicKey);
         public Task<Result<List<AccountBalances>, DomainError>> GetBalances(string publicKey);

--- a/StellarWallet.Infrastructure/Services/StellarService.cs
+++ b/StellarWallet.Infrastructure/Services/StellarService.cs
@@ -44,7 +44,7 @@ namespace StellarWallet.Infrastructure.Services
             return accountKeyPair;
         }
 
-        public async Task<Result<bool, DomainError>> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount)
+        public async Task<Result<bool, DomainError>> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount, string memo)
         {
             KeyPair sourceKeypair = KeyPair.FromSecretSeed(sourceSecretKey);
 
@@ -60,6 +60,7 @@ namespace StellarWallet.Infrastructure.Services
 
                 Transaction transaction = new TransactionBuilder(sourceAccount)
                    .AddOperation(paymentOperation)
+                   .AddMemo(new MemoText(memo))
                    .Build();
 
                 transaction.Sign(sourceKeypair, network);

--- a/StellarWallet.UnitTest/Application/Services/TransactionServiceTest.cs
+++ b/StellarWallet.UnitTest/Application/Services/TransactionServiceTest.cs
@@ -64,11 +64,11 @@ namespace StellarWallet.UnitTest.Application.Services
         [Fact]
         public async Task When_ValidSendPayment_Expected_True()
         {
-            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10);
+            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, "test_memo");
             _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, DomainError>.Success(_validUser.Email));
             _mockUnitOfWork.Setup(x => x.User.GetBy("Email", _validUser.Email)).ReturnsAsync(_validUser);
             _mockAuthService.Setup(x => x.AuthenticateEmail(JWT, _validUser.Email)).Returns(Result<bool, DomainError>.Success(true));
-            _mockBlockchainService.Setup(x => x.SendPayment(_validUser.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString())).ReturnsAsync(Result<bool, DomainError>.Success(true));
+            _mockBlockchainService.Setup(x => x.SendPayment(_validUser.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), "test_memo")).ReturnsAsync(Result<bool, DomainError>.Success(true));
 
             var result = await _sut.SendPayment(sendPaymentDto, JWT);
 
@@ -78,7 +78,7 @@ namespace StellarWallet.UnitTest.Application.Services
         [Fact]
         public async Task When_UnexistingUserSendPayment_Expected_UnsuccessfulResponse()
         {
-            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10);
+            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, "test_memo");
             _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, DomainError>.Success(_validUser.Email));
             _mockUnitOfWork.Setup(x => x.User.GetBy("Email", _validUser.Email)).ReturnsAsync((User)null);
 
@@ -90,11 +90,11 @@ namespace StellarWallet.UnitTest.Application.Services
         [Fact]
         public async Task When_InvalidJwtSendPayment_Expected_UnsuccessfulResponse()
         {
-            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10);
+            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, "test_memo");
             _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, DomainError>.Success(_validUser.Email));
             _mockUnitOfWork.Setup(x => x.User.GetBy("Email", _validUser.Email)).ReturnsAsync(_validUser);
             _mockAuthService.Setup(x => x.AuthenticateEmail(JWT, _validUser.Email)).Returns(Result<bool, DomainError>.Success(true));
-            _mockBlockchainService.Setup(x => x.SendPayment(_validUser.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString())).ReturnsAsync(Result<bool, DomainError>.Failure(DomainError.Unauthorized()));
+            _mockBlockchainService.Setup(x => x.SendPayment(_validUser.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), "test_memo")).ReturnsAsync(Result<bool, DomainError>.Failure(DomainError.Unauthorized()));
 
             var result = await _sut.SendPayment(sendPaymentDto, JWT);
 


### PR DESCRIPTION
# Summary

- Add `Memo` attribute to the `SendPaymentDto` class.
- Add `memo` parameter to the `SendPayment` method in the `StellarService` class and the `IBlockchainService` interface.
- Update the `SendPayment` method of the `TransactionService` class to use the `DTO` memo.
- Update the `TransactionService` unit tests based on the changes to `SendPaymentDto`.

# Details

- The API client will now allow users to add a memo to their payments.