### PR TITLE
ref: send payment to handle memos

### DIFF
--- a/StellarWallet.Application/Services/TransactionService.cs
+++ b/StellarWallet.Application/Services/TransactionService.cs
@@ -47,7 +47,7 @@ namespace StellarWallet.Application.Services
                 return Result<bool, DomainError>.Failure(DomainError.Unauthorized("Unauthorized"));
             }
 
-            var transactionResponse = await _blockchainService.SendPayment(user.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), sendPaymentDto.Memo);
+            var transactionResponse = await _blockchainService.SendPayment(user.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), sendPaymentDto.Memo ?? String.Empty);
 
             bool transactionCompleted = transactionResponse.IsSuccess;
 


### PR DESCRIPTION
# Summary

- Remove unnecessary try catch statement in `StellarService`.
- Update the `SendPayment` method in `StellarService.cs` to add user's memo or an empty string if none.
- Refactor the `SendPayment` endpoint to return the appropiate error.

# Details

- The API will now process payments without memo.