### PR TITLE
ref: get balances add issuer

### DIFF
--- a/StellarWallet.Domain/Structs/AccountBalances.cs
+++ b/StellarWallet.Domain/Structs/AccountBalances.cs
@@ -4,5 +4,6 @@
     {
         public string Asset { get; set; }
         public string Amount { get; set; }
+        public string Issuer { get; set; }
     }
 }

--- a/StellarWallet.Infrastructure/Services/StellarService.cs
+++ b/StellarWallet.Infrastructure/Services/StellarService.cs
@@ -156,6 +156,7 @@ namespace StellarWallet.Infrastructure.Services
                     {
                         Asset = balance.Asset is AssetTypeNative ? "native" : ((AssetTypeCreditAlphaNum)balance.Asset).Code,
                         Amount = balance.BalanceString,
+                        Issuer = balance.Asset is AssetTypeNative ? "native" : ((AssetTypeCreditAlphaNum)balance.Asset).Issuer
                     });
                 }
 


### PR DESCRIPTION
# Summary

- Add `Issuer` attribute to `AccountBalances` `struct`.
- Update the `GetBalances` of the `StellarService` to return the asset issuer.

# Details

- The API will now return the asset issuers when getting balances.