### PR TITLE
feat: payments with any asset

### DIFF
--- a/StellarWallet.Application/Dtos/Requests/SendPaymentDto.cs
+++ b/StellarWallet.Application/Dtos/Requests/SendPaymentDto.cs
@@ -2,16 +2,23 @@
 
 namespace StellarWallet.Application.Dtos.Requests
 {
-    public class SendPaymentDto(string destinationPublicKey, decimal amount, string memo)
+    public class SendPaymentDto(string destinationPublicKey, decimal amount, string? assetIssuer, string? assetCode, string memo)
     {
         [Required(ErrorMessage = "Public key is required")]
         [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
         public string DestinationPublicKey { get; set; } = destinationPublicKey;
 
+        [MaxLength(56, ErrorMessage = "Asset issuer must have 56 characters")]
+        public string AssetIssuer { get; set; } = assetIssuer ?? "native";
+
+        [StringLength(12, MinimumLength = 1, ErrorMessage = "Asset code must have between 1 and 12 characters")]
+        public string AssetCode { get; set; } = assetCode ?? "XLM";
+
+        [Required(ErrorMessage = "Amount is required")]
         [Range(0.0001, double.MaxValue, ErrorMessage = "Invalid amount")]
         public decimal Amount { get; set; } = amount;
 
-        [StringLength(28, MinimumLength = 1, ErrorMessage = "Memo must have between 1 and 28 characters")]
+        [StringLength(28, MinimumLength = 0, ErrorMessage = "Memo must have between 0 and 28 characters")]
         public string? Memo { get; set; } = memo;
     }
 }

--- a/StellarWallet.Application/Services/TransactionService.cs
+++ b/StellarWallet.Application/Services/TransactionService.cs
@@ -47,7 +47,7 @@ namespace StellarWallet.Application.Services
                 return Result<bool, DomainError>.Failure(DomainError.Unauthorized("Unauthorized"));
             }
 
-            var transactionResponse = await _blockchainService.SendPayment(user.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), sendPaymentDto.Memo ?? String.Empty);
+            var transactionResponse = await _blockchainService.SendPayment(user.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), sendPaymentDto.AssetIssuer, sendPaymentDto.AssetCode, sendPaymentDto.Memo ?? String.Empty);
 
             bool transactionCompleted = transactionResponse.IsSuccess;
 

--- a/StellarWallet.Domain/Interfaces/Services/IBlockchainService.cs
+++ b/StellarWallet.Domain/Interfaces/Services/IBlockchainService.cs
@@ -9,7 +9,7 @@ namespace StellarWallet.Domain.Interfaces.Services
     {
         public BlockchainAccount CreateAccount(int userId);
         public AccountKeyPair CreateKeyPair();
-        public Task<Result<bool, DomainError>> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount, string memo);
+        public Task<Result<bool, DomainError>> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount, string assetIssuer, string assetCode, string memo);
         public Task<Result<BlockchainPayment[], DomainError>> GetPayments(string publicKey);
         public Task<Result<bool, DomainError>> GetTestFunds(string publicKey);
         public Task<Result<List<AccountBalances>, DomainError>> GetBalances(string publicKey);

--- a/StellarWallet.Infrastructure/Services/StellarService.cs
+++ b/StellarWallet.Infrastructure/Services/StellarService.cs
@@ -44,7 +44,7 @@ namespace StellarWallet.Infrastructure.Services
             return accountKeyPair;
         }
 
-        public async Task<Result<bool, DomainError>> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount, string memo)
+        public async Task<Result<bool, DomainError>> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount, string assetIssuer, string assetCode, string memo)
         {
             var sourceKeypair = KeyPair.FromSecretSeed(sourceSecretKey);
 
@@ -61,7 +61,9 @@ namespace StellarWallet.Infrastructure.Services
 
             Account sourceAccount = new Account(sourceKeypair.AccountId, sourceAccountResponse.SequenceNumber);
 
-            PaymentOperation paymentOperation = new PaymentOperation.Builder(destinationKeyPair, new AssetTypeNative(), amount).SetSourceAccount(sourceAccount.KeyPair).Build();
+            var asset = assetIssuer == "native" ? (Asset)new AssetTypeNative() : Asset.CreateNonNativeAsset(assetCode, assetIssuer);
+
+            PaymentOperation paymentOperation = new PaymentOperation.Builder(destinationKeyPair, asset, amount).SetSourceAccount(sourceAccount.KeyPair).Build();
 
             Transaction transaction = new TransactionBuilder(sourceAccount)
                .AddOperation(paymentOperation)

--- a/StellarWallet.UnitTest/Application/Services/TransactionServiceTest.cs
+++ b/StellarWallet.UnitTest/Application/Services/TransactionServiceTest.cs
@@ -64,11 +64,11 @@ namespace StellarWallet.UnitTest.Application.Services
         [Fact]
         public async Task When_ValidSendPayment_Expected_True()
         {
-            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, "test_memo");
+            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, string.Empty, string.Empty, "test_memo");
             _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, DomainError>.Success(_validUser.Email));
             _mockUnitOfWork.Setup(x => x.User.GetBy("Email", _validUser.Email)).ReturnsAsync(_validUser);
             _mockAuthService.Setup(x => x.AuthenticateEmail(JWT, _validUser.Email)).Returns(Result<bool, DomainError>.Success(true));
-            _mockBlockchainService.Setup(x => x.SendPayment(_validUser.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), "test_memo")).ReturnsAsync(Result<bool, DomainError>.Success(true));
+            _mockBlockchainService.Setup(x => x.SendPayment(_validUser.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), string.Empty, string.Empty, "test_memo")).ReturnsAsync(Result<bool, DomainError>.Success(true));
 
             var result = await _sut.SendPayment(sendPaymentDto, JWT);
 
@@ -78,7 +78,7 @@ namespace StellarWallet.UnitTest.Application.Services
         [Fact]
         public async Task When_UnexistingUserSendPayment_Expected_UnsuccessfulResponse()
         {
-            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, "test_memo");
+            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, string.Empty, string.Empty, "test_memo");
             _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, DomainError>.Success(_validUser.Email));
             _mockUnitOfWork.Setup(x => x.User.GetBy("Email", _validUser.Email)).ReturnsAsync((User)null);
 
@@ -90,11 +90,11 @@ namespace StellarWallet.UnitTest.Application.Services
         [Fact]
         public async Task When_InvalidJwtSendPayment_Expected_UnsuccessfulResponse()
         {
-            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, "test_memo");
+            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, string.Empty, string.Empty, "test_memo");
             _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, DomainError>.Success(_validUser.Email));
             _mockUnitOfWork.Setup(x => x.User.GetBy("Email", _validUser.Email)).ReturnsAsync(_validUser);
             _mockAuthService.Setup(x => x.AuthenticateEmail(JWT, _validUser.Email)).Returns(Result<bool, DomainError>.Success(true));
-            _mockBlockchainService.Setup(x => x.SendPayment(_validUser.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), "test_memo")).ReturnsAsync(Result<bool, DomainError>.Failure(DomainError.Unauthorized()));
+            _mockBlockchainService.Setup(x => x.SendPayment(_validUser.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), string.Empty, string.Empty, "test_memo")).ReturnsAsync(Result<bool, DomainError>.Failure(DomainError.Unauthorized()));
 
             var result = await _sut.SendPayment(sendPaymentDto, JWT);
 


### PR DESCRIPTION
# Summary

- Add `AssetIssuer` and `AssetCode` attributes to the `SendPaymentDto` class.
- Update `SendPayment` method in `TransactionService.cs` to use the new DTO attributes.
- Refactor `SendPayment` method in `StellarService` to use the asset specified in the DTO and update its interface.
- Update `TransactionServiceTest.cs` by adding values to the new attributes when instantiating the `SendPaymentDto` class.

# Details

- The API client can now specify the asset to send when making a payment. Otherwise, the native Stellar asset is used.