### PR TITLE
ref: payments response

### DIFF
--- a/StellarWallet.Application/Dtos/Responses/TransactionsDto.cs
+++ b/StellarWallet.Application/Dtos/Responses/TransactionsDto.cs
@@ -1,0 +1,10 @@
+using StellarWallet.Domain.Structs;
+
+namespace StellarWallet.Application.Dtos.Responses
+{
+    public class TransactionsDto(List<BlockchainPayment> payments, int totalPages)
+    {
+        public List<BlockchainPayment> Payments { get; set; } = payments;
+        public int TotalPages { get; set; } = totalPages;
+    }
+}

--- a/StellarWallet.Application/Interfaces/ITransactionService.cs
+++ b/StellarWallet.Application/Interfaces/ITransactionService.cs
@@ -3,7 +3,6 @@ using StellarWallet.Application.Dtos.Responses;
 using StellarWallet.Domain.Entities;
 using StellarWallet.Domain.Errors;
 using StellarWallet.Domain.Result;
-using StellarWallet.Domain.Structs;
 
 namespace StellarWallet.Application.Interfaces
 {
@@ -11,7 +10,7 @@ namespace StellarWallet.Application.Interfaces
     {
         public Task<Result<BlockchainAccount, DomainError>> CreateAccount(string jwt);
         public Task<Result<bool, DomainError>> SendPayment(SendPaymentDto sendPaymentDto, string jwt);
-        public Task<Result<BlockchainPayment[], DomainError>> GetTransaction(string jwt, int pageNumber, int pageSize);
+        public Task<Result<TransactionsDto, DomainError>> GetTransaction(string jwt, int pageNumber, int pageSize);
         public Task<Result<bool, DomainError>> GetTestFunds(string publicKey);
         public Task<Result<FoundBalancesDto, DomainError>> GetBalances(GetBalancesDto publicKey);
     }

--- a/StellarWallet.UnitTest/Application/Services/TransactionServiceTest.cs
+++ b/StellarWallet.UnitTest/Application/Services/TransactionServiceTest.cs
@@ -127,8 +127,8 @@ namespace StellarWallet.UnitTest.Application.Services
 
             var result = await _sut.GetTransaction(JWT, pageNumber, pageSize);
 
-            Assert.True(result.Value.Length == pageSize);
-            Assert.Equal(result.Value[0], blockchainPayments[0]);
+            Assert.True(result.Value.Payments.Count == pageSize);
+            Assert.Equal(result.Value.Payments[0], blockchainPayments[0]);
         }
 
         [Fact]


### PR DESCRIPTION
# Summary

- Add `TransactionsDto` class to handle responses with payments and total pages.
- Refactor `GetTransaction` method in `TransactionService.cs` and its interface to return paginated transactions.
- Refactor `GetTransaction` test in T`ransactionServiceTest.cs`.

# Details

- The API will now return the number of pages when getting all payments.