### PR TITLE
ref: code formatter and linter

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,14 +2,18 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "husky": {
-      "version": "0.7.0",
-      "commands": ["husky"],
+    "csharpier": {
+      "version": "0.30.3",
+      "commands": [
+        "dotnet-csharpier"
+      ],
       "rollForward": false
     },
-    "dotnet-format": {
-      "version": "5.1.250801",
-      "commands": ["dotnet-format"],
+    "husky": {
+      "version": "0.7.2",
+      "commands": [
+        "husky"
+      ],
       "rollForward": false
     }
   }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,292 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+# Here we set all microsoft's IDExxxx rule violations as compile errors
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/
+dotnet_analyzer_diagnostic.category-Style.severity = error
+
+# Here we ignore some rule violdations that they are not really important for us
+dotnet_diagnostic.IDE0008.severity = silent # Explicit type, not var
+dotnet_diagnostic.IDE0010.severity = silent # missing cases to "case" switch expression
+dotnet_diagnostic.IDE0039.severity = silent # lambda vs local function
+dotnet_diagnostic.IDE0045.severity = silent # Use ternary for assignment, not ifs
+dotnet_diagnostic.IDE0046.severity = silent # Use ternary for returns, not ifs
+dotnet_diagnostic.IDE0055.severity = silent # Generic formatting errors: should be handled by csharpier
+dotnet_diagnostic.IDE0058.severity = silent # Expression value is never used
+dotnet_diagnostic.IDE0072.severity = silent # missing cases to "=>" switch expression
+dotnet_diagnostic.IDE0090.severity = silent # Use implicit new
+dotnet_diagnostic.IDE0270.severity = silent # Simplify null check
+dotnet_diagnostic.IDE0290.severity = silent # Use primary constructor
+dotnet_diagnostic.IDE0028.severity = silent # Use collection initializers or expressions
+dotnet_diagnostic.IDE0301.severity = silent # Use collection expression for empty
+dotnet_diagnostic.IDE0300.severity = silent # Use collection expression for array
+dotnet_diagnostic.CA1859.severity = silent # Use concrete types when possible for improved performance
+
+# https://github.com/dotnet/aspnetcore/issues/47912
+ dotnet_diagnostic.IDE0005.severity = none # Remove unnecessary using directives (using CS8019 instead)
+ dotnet_diagnostic.CS8019.severity = error # Remove unnecessary using directives
+
+# Here we set some rules for unused codes (classes, methods, parameters, etc.)
+dotnet_diagnostic.CA1801.severity = error # Review unused parameters
+dotnet_diagnostic.CA1804.severity = error # Remove unused locals
+dotnet_diagnostic.CA1811.severity = error # Avoid uncalled private code
+dotnet_diagnostic.CA1823.severity = error # Avoid unused private fields
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+file_header_template = unset
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false:error
+dotnet_style_qualification_for_method = false:error
+dotnet_style_qualification_for_property = false:error
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary
+dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = true
+dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# Field preferences
+dotnet_style_readonly_field = true
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = true
+dotnet_style_allow_statement_immediately_after_block_experimental = true
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = true:silent
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_methods = when_on_single_line:none
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = false
+csharp_style_pattern_matching_over_is_with_cast_check = false
+csharp_style_prefer_extended_property_pattern = false
+csharp_style_prefer_not_pattern = false
+csharp_style_prefer_pattern_matching = false
+csharp_style_prefer_switch_expression = false
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true
+
+# Modifier preferences
+csharp_prefer_static_local_function = true
+csharp_preferred_modifier_order = public, private, protected, internal, file, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, required, volatile, async
+csharp_style_prefer_readonly_struct = true
+
+# Code-block preferences
+csharp_prefer_braces = when_multiline:error
+csharp_prefer_simple_using_statement = false:silent
+csharp_style_namespace_declarations = file_scoped:error
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = false:silent
+csharp_style_implicit_class_creation = false:silent
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true
+csharp_style_deconstructed_variable_declaration = true
+csharp_style_implicit_object_creation_when_type_is_apparent = false
+csharp_style_inlined_variable_declaration = true
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_local_over_anonymous_function = true
+csharp_style_prefer_null_check_over_type_check = true
+csharp_style_prefer_range_operator = true
+csharp_style_prefer_tuple_swap = true
+csharp_style_prefer_utf8_string_literals = true
+csharp_style_throw_expression = true
+csharp_style_unused_value_assignment_preference = discard_variable
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:silent
+
+# New line preferences
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
+csharp_style_allow_embedded_statements_on_same_line_experimental = true
+
+#### C# Formatting Rules ####
+# All handled by csharpier
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = error
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = error
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.constant_should_be_capitalized_snake_case.severity = error
+dotnet_naming_rule.constant_should_be_capitalized_snake_case.symbols = constant
+dotnet_naming_rule.constant_should_be_capitalized_snake_case.style = capitalized_snake_case
+
+dotnet_naming_rule.readonly_should_be_begins_with__.severity = error
+dotnet_naming_rule.readonly_should_be_begins_with__.symbols = readonly
+dotnet_naming_rule.readonly_should_be_begins_with__.style = begins_with__
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = error
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.private_or_internal_field_should_be_camel_case.severity = error
+dotnet_naming_rule.private_or_internal_field_should_be_camel_case.symbols = private_or_internal_field
+dotnet_naming_rule.private_or_internal_field_should_be_camel_case.style = camel_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+
+dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
+dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = internal, private, private_protected
+dotnet_naming_symbols.private_or_internal_field.required_modifiers =
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+
+dotnet_naming_symbols.constant.applicable_kinds = field
+dotnet_naming_symbols.constant.applicable_accessibilities = public, internal, private
+dotnet_naming_symbols.constant.required_modifiers = const
+
+dotnet_naming_symbols.readonly.applicable_kinds = field
+dotnet_naming_symbols.readonly.applicable_accessibilities = public, private
+dotnet_naming_symbols.readonly.required_modifiers = readonly
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix =
+dotnet_naming_style.begins_with_i.word_separator =
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.camel_case.required_prefix =
+dotnet_naming_style.camel_case.required_suffix =
+dotnet_naming_style.camel_case.word_separator =
+dotnet_naming_style.camel_case.capitalization = camel_case
+
+dotnet_naming_style.capitalized_snake_case.required_prefix =
+dotnet_naming_style.capitalized_snake_case.required_suffix =
+dotnet_naming_style.capitalized_snake_case.word_separator = _
+dotnet_naming_style.capitalized_snake_case.capitalization = all_upper
+
+dotnet_naming_style.begins_with__.required_prefix = _
+dotnet_naming_style.begins_with__.required_suffix =
+dotnet_naming_style.begins_with__.word_separator =
+dotnet_naming_style.begins_with__.capitalization = camel_case
+
+[*.{cs,vb}]
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+
+##
+## SonarAnalyzers.CSharp
+##
+
+# Update this method so that its implementation is not identical to 'blah'
+dotnet_diagnostic.S4144.severity = None
+    
+# Update this implementation of 'ISerializable' to conform to the recommended serialization pattern
+dotnet_diagnostic.S3925.severity = None
+    
+# Rename class 'IOCActivator' to match pascal case naming rules, consider using 'IocActivator'
+dotnet_diagnostic.S101.severity = None
+    
+# Extract this nested code block into a separate method
+dotnet_diagnostic.S1199.severity = None
+
+# Remove unassigned auto-property 'Blah', or set its value
+dotnet_diagnostic.S3459.severity = None
+
+# Remove the unused private set accessor in property 'Version'
+dotnet_diagnostic.S1144.severity = None
+
+# Remove this commented out code
+dotnet_diagnostic.S125.severity = None
+    
+# 'System.Exception' should not be thrown by user code
+dotnet_diagnostic.S112.severity = None

--- a/.editorconfig
+++ b/.editorconfig
@@ -263,6 +263,10 @@ dotnet_style_collection_initializer = true:suggestion
 dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
 dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 
+# Exclude migrations
+[**/Migrations/**/*.cs]
+dotnet_analyzer_diagnostic.category-Style.severity = none
+
 ##
 ## SonarAnalyzers.CSharp
 ##

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,25 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-## husky task runner examples -------------------
-## Note : for local installation use 'dotnet' prefix. e.g. 'dotnet husky'
-
-## run all tasks
-#husky run
-
-### run all tasks with group: 'group-name'
-#husky run --group group-name
-
-## run task with name: 'task-name'
-#husky run --name task-name
-
-## pass hook arguments to task
-#husky run --args "$1" "$2"
-
-## or put your custom commands -------------------
-#echo 'Husky.Net is awesome!'
-
-echo 'Welcome to pre-commit git hook with Husky.Net'
-
 echo 'Run Dotnet Format'
 dotnet format

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-echo 'Run Dotnet Format'
-dotnet format
+echo 'Run Formatter and Linter'
+dotnet husky run

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,26 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-## husky task runner examples -------------------
-## Note : for local installation use 'dotnet' prefix. e.g. 'dotnet husky'
-
-## run all tasks
-#husky run
-
-### run all tasks with group: 'group-name'
-#husky run --group group-name
-
-## run task with name: 'task-name'
-#husky run --name task-name
-
-## pass hook arguments to task
-#husky run --args "$1" "$2"
-
-## or put your custom commands -------------------
-#echo 'Husky.Net is awesome!'
-
-echo 'Welcome to pre-push git hook with Husky.Net'
-
 echo 'Clean Project'
 dotnet clean
 

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -2,10 +2,26 @@
    "$schema": "https://alirezanet.github.io/Husky.Net/schema.json",
    "tasks": [
       {
-         "name": "prettier",
-         "command": "npx",
-         "args": ["prettier", "--ignore-unknown", "--write", "${staged}"],
-         "pathMode": "absolute"
-       }
+         "name": "Run csharpier",
+         "command": "dotnet",
+         "args": [
+            "csharpier",
+            "${staged}"
+         ],
+         "include": [
+            "**/*.cs"
+         ]
+      },
+      {
+         "name": "Run SonarAnalyzer",
+         "command": "dotnet",
+         "args": [
+            "build",
+            "/p:EnableStyleCopAnalyzers=true"
+         ],
+         "include": [
+            "**/*.csproj"
+         ]
+      }
    ]
 }

--- a/StellarWallet.Application/Dtos/Requests/AddContactDto.cs
+++ b/StellarWallet.Application/Dtos/Requests/AddContactDto.cs
@@ -1,15 +1,14 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace StellarWallet.Application.Dtos.Requests
-{
-    public class AddContactDto(string alias, string publicKey)
-    {
-        [Required(ErrorMessage = "Alias is required")]
-        [StringLength(50, MinimumLength = 3, ErrorMessage = "Alias must have a maximum of 50 characters and a minimum of 3")]
-        public string Alias { get; set; } = alias;
+namespace StellarWallet.Application.Dtos.Requests;
 
-        [Required(ErrorMessage = "Public key is required")]
-        [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
-        public string PublicKey { get; set; } = publicKey;
-    }
+public class AddContactDto(string alias, string publicKey)
+{
+    [Required(ErrorMessage = "Alias is required")]
+    [StringLength(50, MinimumLength = 3, ErrorMessage = "Alias must have a maximum of 50 characters and a minimum of 3")]
+    public string Alias { get; set; } = alias;
+
+    [Required(ErrorMessage = "Public key is required")]
+    [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
+    public string PublicKey { get; set; } = publicKey;
 }

--- a/StellarWallet.Application/Dtos/Requests/AddWalletDto.cs
+++ b/StellarWallet.Application/Dtos/Requests/AddWalletDto.cs
@@ -1,15 +1,14 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace StellarWallet.Application.Dtos.Requests
-{
-    public class AddWalletDto(string PublicKey, string SecretKey)
-    {
-        [Required(ErrorMessage = "Public key is required")]
-        [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
-        public string PublicKey { get; set; } = PublicKey;
+namespace StellarWallet.Application.Dtos.Requests;
 
-        [Required(ErrorMessage = "Secret key is required")]
-        [StringLength(56, MinimumLength = 56, ErrorMessage = "Secret key must have 56 characters")]
-        public string SecretKey { get; set; } = SecretKey;
-    }
+public class AddWalletDto(string PublicKey, string SecretKey)
+{
+    [Required(ErrorMessage = "Public key is required")]
+    [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
+    public string PublicKey { get; set; } = PublicKey;
+
+    [Required(ErrorMessage = "Secret key is required")]
+    [StringLength(56, MinimumLength = 56, ErrorMessage = "Secret key must have 56 characters")]
+    public string SecretKey { get; set; } = SecretKey;
 }

--- a/StellarWallet.Application/Dtos/Requests/GetBalancesDto.cs
+++ b/StellarWallet.Application/Dtos/Requests/GetBalancesDto.cs
@@ -1,23 +1,22 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace StellarWallet.Application.Dtos.Requests
+namespace StellarWallet.Application.Dtos.Requests;
+
+public class GetBalancesDto
 {
-    public class GetBalancesDto
-    {
-        [Required(ErrorMessage = "Public key is required")]
-        [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
-        public string PublicKey { get; set; } = string.Empty;
+    [Required(ErrorMessage = "Public key is required")]
+    [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
+    public string PublicKey { get; set; } = string.Empty;
 
-        public bool FilterZeroBalances { get; set; } = false;
+    public bool FilterZeroBalances { get; set; } = false;
 
-        [Required]
-        [Range(1, int.MaxValue)]
-        public int PageNumber { get; set; }
+    [Required]
+    [Range(1, int.MaxValue)]
+    public int PageNumber { get; set; }
 
-        [Required]
-        [Range(1, int.MaxValue)]
-        public int PageSize { get; set; }
+    [Required]
+    [Range(1, int.MaxValue)]
+    public int PageSize { get; set; }
 
-        public GetBalancesDto() { }
-    }
+    public GetBalancesDto() { }
 }

--- a/StellarWallet.Application/Dtos/Requests/GetTestFundsDto.cs
+++ b/StellarWallet.Application/Dtos/Requests/GetTestFundsDto.cs
@@ -1,11 +1,10 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace StellarWallet.Application.Dtos.Requests
+namespace StellarWallet.Application.Dtos.Requests;
+
+public class GetTestFundsDto(string publicKey)
 {
-    public class GetTestFundsDto(string publicKey)
-    {
-        [Required(ErrorMessage = "Public key is required")]
-        [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
-        public string PublicKey { get; set; } = publicKey;
-    }
+    [Required(ErrorMessage = "Public key is required")]
+    [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
+    public string PublicKey { get; set; } = publicKey;
 }

--- a/StellarWallet.Application/Dtos/Requests/LoginDto.cs
+++ b/StellarWallet.Application/Dtos/Requests/LoginDto.cs
@@ -1,14 +1,13 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace StellarWallet.Application.Dtos.Requests
-{
-    public class LoginDto(string email, string password)
-    {
-        [EmailAddress(ErrorMessage = "Must be a valid email address"), Required(ErrorMessage = "Email must be provided")]
-        public string Email { get; set; } = email;
+namespace StellarWallet.Application.Dtos.Requests;
 
-        [Required(ErrorMessage = "Password must be provided")]
-        [Length(8, 50, ErrorMessage = "Password must have between 8 and 50 characters")]
-        public string Password { get; set; } = password;
-    }
+public class LoginDto(string email, string password)
+{
+    [EmailAddress(ErrorMessage = "Must be a valid email address"), Required(ErrorMessage = "Email must be provided")]
+    public string Email { get; set; } = email;
+
+    [Required(ErrorMessage = "Password must be provided")]
+    [Length(8, 50, ErrorMessage = "Password must have between 8 and 50 characters")]
+    public string Password { get; set; } = password;
 }

--- a/StellarWallet.Application/Dtos/Requests/SendPaymentDto.cs
+++ b/StellarWallet.Application/Dtos/Requests/SendPaymentDto.cs
@@ -1,24 +1,23 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace StellarWallet.Application.Dtos.Requests
+namespace StellarWallet.Application.Dtos.Requests;
+
+public class SendPaymentDto(string destinationPublicKey, decimal amount, string? assetIssuer, string? assetCode, string memo)
 {
-    public class SendPaymentDto(string destinationPublicKey, decimal amount, string? assetIssuer, string? assetCode, string memo)
-    {
-        [Required(ErrorMessage = "Public key is required")]
-        [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
-        public string DestinationPublicKey { get; set; } = destinationPublicKey;
+    [Required(ErrorMessage = "Public key is required")]
+    [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
+    public string DestinationPublicKey { get; set; } = destinationPublicKey;
 
-        [MaxLength(56, ErrorMessage = "Asset issuer must have 56 characters")]
-        public string AssetIssuer { get; set; } = assetIssuer ?? "native";
+    [MaxLength(56, ErrorMessage = "Asset issuer must have 56 characters")]
+    public string AssetIssuer { get; set; } = assetIssuer ?? "native";
 
-        [StringLength(12, MinimumLength = 1, ErrorMessage = "Asset code must have between 1 and 12 characters")]
-        public string AssetCode { get; set; } = assetCode ?? "XLM";
+    [StringLength(12, MinimumLength = 1, ErrorMessage = "Asset code must have between 1 and 12 characters")]
+    public string AssetCode { get; set; } = assetCode ?? "XLM";
 
-        [Required(ErrorMessage = "Amount is required")]
-        [Range(0.0001, double.MaxValue, ErrorMessage = "Invalid amount")]
-        public decimal Amount { get; set; } = amount;
+    [Required(ErrorMessage = "Amount is required")]
+    [Range(0.0001, double.MaxValue, ErrorMessage = "Invalid amount")]
+    public decimal Amount { get; set; } = amount;
 
-        [StringLength(28, MinimumLength = 0, ErrorMessage = "Memo must have between 0 and 28 characters")]
-        public string? Memo { get; set; } = memo;
-    }
+    [StringLength(28, MinimumLength = 0, ErrorMessage = "Memo must have between 0 and 28 characters")]
+    public string? Memo { get; set; } = memo;
 }

--- a/StellarWallet.Application/Dtos/Requests/UpdateContactDto.cs
+++ b/StellarWallet.Application/Dtos/Requests/UpdateContactDto.cs
@@ -1,20 +1,19 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace StellarWallet.Application.Dtos.Requests
+namespace StellarWallet.Application.Dtos.Requests;
+
+public class UpdateContactDto(int id, string? alias, int? userId, int? blockchainAccountId)
 {
-    public class UpdateContactDto(int id, string? alias, int? userId, int? blockchainAccountId)
-    {
-        [Required(ErrorMessage = "User contact id is required")]
-        [Range(1, int.MaxValue, ErrorMessage = "User contact id must be positive")]
-        public int Id { get; set; } = id;
+    [Required(ErrorMessage = "User contact id is required")]
+    [Range(1, int.MaxValue, ErrorMessage = "User contact id must be positive")]
+    public int Id { get; set; } = id;
 
-        [StringLength(50, MinimumLength = 3, ErrorMessage = "Alias must have a maximum of 50 characters and a minimum of 3")]
-        public string? Alias { get; set; } = alias;
+    [StringLength(50, MinimumLength = 3, ErrorMessage = "Alias must have a maximum of 50 characters and a minimum of 3")]
+    public string? Alias { get; set; } = alias;
 
-        [Range(1, int.MaxValue, ErrorMessage = "User id must be positive")]
-        public int? UserId { get; set; } = userId;
+    [Range(1, int.MaxValue, ErrorMessage = "User id must be positive")]
+    public int? UserId { get; set; } = userId;
 
-        [Range(1, int.MaxValue, ErrorMessage = "BlockchainAccount id must be positive")]
-        public int? BlockchainAccountId { get; set; } = blockchainAccountId;
-    }
+    [Range(1, int.MaxValue, ErrorMessage = "BlockchainAccount id must be positive")]
+    public int? BlockchainAccountId { get; set; } = blockchainAccountId;
 }

--- a/StellarWallet.Application/Dtos/Requests/UserCreationDto.cs
+++ b/StellarWallet.Application/Dtos/Requests/UserCreationDto.cs
@@ -1,33 +1,32 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace StellarWallet.Application.Dtos.Requests
+namespace StellarWallet.Application.Dtos.Requests;
+
+public class UserCreationDto(string Name, string LastName, string Email, string Password, string? PublicKey, string? SecretKey)
 {
-    public class UserCreationDto(string Name, string LastName, string Email, string Password, string? PublicKey, string? SecretKey)
-    {
-        [Required(ErrorMessage = "Name is required")]
-        [StringLength(50, MinimumLength = 3, ErrorMessage = "Name must have a maximum of 50 characters and a minimun of 3.")]
-        [RegularExpression(@"^[a-zA-Z''-'\s]{3,50}$", ErrorMessage = "Special characters are not allowed.")]
-        public string Name { get; set; } = Name;
+    [Required(ErrorMessage = "Name is required")]
+    [StringLength(50, MinimumLength = 3, ErrorMessage = "Name must have a maximum of 50 characters and a minimun of 3.")]
+    [RegularExpression(@"^[a-zA-Z''-'\s]{3,50}$", ErrorMessage = "Special characters are not allowed.")]
+    public string Name { get; set; } = Name;
 
-        [Required(ErrorMessage = "Lastname is required")]
-        [StringLength(50, MinimumLength = 3, ErrorMessage = "Lastname must have a maximum of 50 characters and a minimun of 3.")]
-        [RegularExpression(@"^[a-zA-Z''-'\s]{3,50}$", ErrorMessage = "Special characters are not allowed.")]
-        public string LastName { get; set; } = LastName;
+    [Required(ErrorMessage = "Lastname is required")]
+    [StringLength(50, MinimumLength = 3, ErrorMessage = "Lastname must have a maximum of 50 characters and a minimun of 3.")]
+    [RegularExpression(@"^[a-zA-Z''-'\s]{3,50}$", ErrorMessage = "Special characters are not allowed.")]
+    public string LastName { get; set; } = LastName;
 
-        [Required(ErrorMessage = "Email is required")]
-        [EmailAddress(ErrorMessage = "Invalid email")]
-        public string Email { get; set; } = Email;
+    [Required(ErrorMessage = "Email is required")]
+    [EmailAddress(ErrorMessage = "Invalid email")]
+    public string Email { get; set; } = Email;
 
-        [Required(ErrorMessage = "Password is required")]
-        [StringLength(50, MinimumLength = 8, ErrorMessage = "Password must have a maximum of 50 characters and a minimun of 8.")]
-        public string Password { get; set; } = Password;
+    [Required(ErrorMessage = "Password is required")]
+    [StringLength(50, MinimumLength = 8, ErrorMessage = "Password must have a maximum of 50 characters and a minimun of 8.")]
+    public string Password { get; set; } = Password;
 
-        [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters.")]
-        [RegularExpression(@"^[a-zA-Z''-'\s]{56}$", ErrorMessage = "Special characters are not allowed.")]
-        public string? PublicKey { get; set; } = PublicKey;
+    [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters.")]
+    [RegularExpression(@"^[a-zA-Z''-'\s]{56}$", ErrorMessage = "Special characters are not allowed.")]
+    public string? PublicKey { get; set; } = PublicKey;
 
-        [StringLength(56, MinimumLength = 56, ErrorMessage = "Secret key must have 56 characters.")]
-        [RegularExpression(@"^[a-zA-Z''-'\s]{56}$", ErrorMessage = "Special characters are not allowed.")]
-        public string? SecretKey { get; set; } = SecretKey;
-    }
+    [StringLength(56, MinimumLength = 56, ErrorMessage = "Secret key must have 56 characters.")]
+    [RegularExpression(@"^[a-zA-Z''-'\s]{56}$", ErrorMessage = "Special characters are not allowed.")]
+    public string? SecretKey { get; set; } = SecretKey;
 }

--- a/StellarWallet.Application/Dtos/Requests/UserUpdateDto.cs
+++ b/StellarWallet.Application/Dtos/Requests/UserUpdateDto.cs
@@ -1,33 +1,32 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace StellarWallet.Application.Dtos.Requests
+namespace StellarWallet.Application.Dtos.Requests;
+
+public class UserUpdateDto(int Id, string? Name, string? LastName, string? Email, string? Password, string? PublicKey, string? SecretKey)
 {
-    public class UserUpdateDto(int Id, string? Name, string? LastName, string? Email, string? Password, string? PublicKey, string? SecretKey)
-    {
-        [Required]
-        [Range(1, int.MaxValue, ErrorMessage = "Id must be a positive number")]
-        public int Id { get; } = Id;
+    [Required]
+    [Range(1, int.MaxValue, ErrorMessage = "Id must be a positive number")]
+    public int Id { get; } = Id;
 
-        [StringLength(50, MinimumLength = 6, ErrorMessage = "Name must have a maximum of 50 characters and a minimun of 6")]
-        [RegularExpression(@"^[a-zA-Z''-'\s]{1,50}$", ErrorMessage = "Special characters are not allowed.")]
-        public string? Name { get; set; } = Name;
+    [StringLength(50, MinimumLength = 6, ErrorMessage = "Name must have a maximum of 50 characters and a minimun of 6")]
+    [RegularExpression(@"^[a-zA-Z''-'\s]{1,50}$", ErrorMessage = "Special characters are not allowed.")]
+    public string? Name { get; set; } = Name;
 
-        [StringLength(50, MinimumLength = 6, ErrorMessage = "Lastname must have a maximum of 50 characters and a minimun of 6")]
-        [RegularExpression(@"^[a-zA-Z''-'\s]{1,50}$", ErrorMessage = "Special characters are not allowed.")]
-        public string? LastName { get; set; } = LastName;
+    [StringLength(50, MinimumLength = 6, ErrorMessage = "Lastname must have a maximum of 50 characters and a minimun of 6")]
+    [RegularExpression(@"^[a-zA-Z''-'\s]{1,50}$", ErrorMessage = "Special characters are not allowed.")]
+    public string? LastName { get; set; } = LastName;
 
-        [EmailAddress(ErrorMessage = "Invalid email")]
-        public string? Email { get; set; } = Email;
+    [EmailAddress(ErrorMessage = "Invalid email")]
+    public string? Email { get; set; } = Email;
 
-        [StringLength(50, MinimumLength = 8, ErrorMessage = "Password must have a maximum of 50 characters and a minimun of 8")]
-        public string? Password { get; set; } = Password;
+    [StringLength(50, MinimumLength = 8, ErrorMessage = "Password must have a maximum of 50 characters and a minimun of 8")]
+    public string? Password { get; set; } = Password;
 
-        [StringLength(57, MinimumLength = 56, ErrorMessage = "Public key must have a maximum of 57 characters and a minimun of 56")]
-        [RegularExpression(@"^[a-zA-Z''-'\s]{1,57}$", ErrorMessage = "Special characters are not allowed.")]
-        public string? PublicKey { get; set; } = PublicKey;
+    [StringLength(57, MinimumLength = 56, ErrorMessage = "Public key must have a maximum of 57 characters and a minimun of 56")]
+    [RegularExpression(@"^[a-zA-Z''-'\s]{1,57}$", ErrorMessage = "Special characters are not allowed.")]
+    public string? PublicKey { get; set; } = PublicKey;
 
-        [StringLength(57, MinimumLength = 56, ErrorMessage = "Secret key must have a maximum of 57 characters and a minimun of 56")]
-        [RegularExpression(@"^[a-zA-Z''-'\s]{1,57}$", ErrorMessage = "Special characters are not allowed.")]
-        public string? SecretKey { get; set; } = SecretKey;
-    }
+    [StringLength(57, MinimumLength = 56, ErrorMessage = "Secret key must have a maximum of 57 characters and a minimun of 56")]
+    [RegularExpression(@"^[a-zA-Z''-'\s]{1,57}$", ErrorMessage = "Special characters are not allowed.")]
+    public string? SecretKey { get; set; } = SecretKey;
 }

--- a/StellarWallet.Application/Dtos/Responses/BlockchainAccountDto.cs
+++ b/StellarWallet.Application/Dtos/Responses/BlockchainAccountDto.cs
@@ -1,8 +1,7 @@
-﻿namespace StellarWallet.Application.Dtos.Responses
+﻿namespace StellarWallet.Application.Dtos.Responses;
+
+public class BlockchainAccountDto
 {
-    public class BlockchainAccountDto
-    {
-        public string? PublicKey { get; set; }
-        public string? SecretKey { get; set; }
-    }
+    public string? PublicKey { get; set; }
+    public string? SecretKey { get; set; }
 }

--- a/StellarWallet.Application/Dtos/Responses/FoundBalancesDto.cs
+++ b/StellarWallet.Application/Dtos/Responses/FoundBalancesDto.cs
@@ -1,10 +1,9 @@
 ﻿using StellarWallet.Domain.Structs;
 
-namespace StellarWallet.Application.Dtos.Responses
+namespace StellarWallet.Application.Dtos.Responses;
+
+public class FoundBalancesDto(List<AccountBalances> balances, int totalPages)
 {
-    public class FoundBalancesDto(List<AccountBalances> balances, int totalPages)
-    {
-        public List<AccountBalances> Balances { get; set; } = balances;
-        public int TotalPages { get; set; } = totalPages;
-    }
+    public List<AccountBalances> Balances { get; set; } = balances;
+    public int TotalPages { get; set; } = totalPages;
 }

--- a/StellarWallet.Application/Dtos/Responses/LoggedDto.cs
+++ b/StellarWallet.Application/Dtos/Responses/LoggedDto.cs
@@ -1,9 +1,8 @@
-﻿namespace StellarWallet.Application.Dtos.Responses
+﻿namespace StellarWallet.Application.Dtos.Responses;
+
+public class LoggedDto(bool success, string? token, string? publicKey)
 {
-    public class LoggedDto(bool success, string? token, string? publicKey)
-    {
-        public bool Success { get; set; } = success;
-        public string? Token { get; set; } = token;
-        public string? PublicKey { get; set; } = publicKey;
-    }
+    public bool Success { get; set; } = success;
+    public string? Token { get; set; } = token;
+    public string? PublicKey { get; set; } = publicKey;
 }

--- a/StellarWallet.Application/Dtos/Responses/TransactionsDto.cs
+++ b/StellarWallet.Application/Dtos/Responses/TransactionsDto.cs
@@ -1,10 +1,9 @@
 using StellarWallet.Domain.Structs;
 
-namespace StellarWallet.Application.Dtos.Responses
+namespace StellarWallet.Application.Dtos.Responses;
+
+public class TransactionsDto(List<BlockchainPayment> payments, int totalPages)
 {
-    public class TransactionsDto(List<BlockchainPayment> payments, int totalPages)
-    {
-        public List<BlockchainPayment> Payments { get; set; } = payments;
-        public int TotalPages { get; set; } = totalPages;
-    }
+    public List<BlockchainPayment> Payments { get; set; } = payments;
+    public int TotalPages { get; set; } = totalPages;
 }

--- a/StellarWallet.Application/Dtos/Responses/UserContactsDto.cs
+++ b/StellarWallet.Application/Dtos/Responses/UserContactsDto.cs
@@ -1,8 +1,7 @@
-﻿namespace StellarWallet.Application.Dtos.Responses
+﻿namespace StellarWallet.Application.Dtos.Responses;
+
+public class UserContactsDto
 {
-    public class UserContactsDto
-    {
-        public string? Alias { get; set; }
-        public string? PublicKey { get; set; }
-    }
+    public string? Alias { get; set; }
+    public string? PublicKey { get; set; }
 }

--- a/StellarWallet.Application/Dtos/Responses/UserDto.cs
+++ b/StellarWallet.Application/Dtos/Responses/UserDto.cs
@@ -1,13 +1,12 @@
-﻿namespace StellarWallet.Application.Dtos.Responses
+﻿namespace StellarWallet.Application.Dtos.Responses;
+
+public class UserDto(int Id, string name, string lastName, string email, string publicKey, ICollection<BlockchainAccountDto>? blockchainAccounts, ICollection<UserContactsDto> userContacts)
 {
-    public class UserDto(int Id, string name, string lastName, string email, string publicKey, ICollection<BlockchainAccountDto>? blockchainAccounts, ICollection<UserContactsDto> userContacts)
-    {
-        public int Id { get; set; } = Id;
-        public string Name { get; set; } = name;
-        public string LastName { get; set; } = lastName;
-        public string Email { get; set; } = email;
-        public string PublicKey { get; set; } = publicKey;
-        public ICollection<BlockchainAccountDto>? BlockchainAccounts { get; set; } = blockchainAccounts;
-        public ICollection<UserContactsDto>? UserContacts { get; set; } = userContacts;
-    }
+    public int Id { get; set; } = Id;
+    public string Name { get; set; } = name;
+    public string LastName { get; set; } = lastName;
+    public string Email { get; set; } = email;
+    public string PublicKey { get; set; } = publicKey;
+    public ICollection<BlockchainAccountDto>? BlockchainAccounts { get; set; } = blockchainAccounts;
+    public ICollection<UserContactsDto>? UserContacts { get; set; } = userContacts;
 }

--- a/StellarWallet.Application/Interfaces/IAuthService.cs
+++ b/StellarWallet.Application/Interfaces/IAuthService.cs
@@ -3,12 +3,11 @@ using StellarWallet.Application.Dtos.Responses;
 using StellarWallet.Domain.Errors;
 using StellarWallet.Domain.Result;
 
-namespace StellarWallet.Application.Interfaces
+namespace StellarWallet.Application.Interfaces;
+
+public interface IAuthService
 {
-    public interface IAuthService
-    {
-        Task<Result<LoggedDto, CustomError>> Login(LoginDto loginDto);
-        Result<bool, CustomError> AuthenticateEmail(string jwt, string email);
-        Task<Result<bool, CustomError>> AuthenticateToken(string jwt);
-    }
+    Task<Result<LoggedDto, CustomError>> Login(LoginDto loginDto);
+    Result<bool, CustomError> AuthenticateEmail(string jwt, string email);
+    Task<Result<bool, CustomError>> AuthenticateToken(string jwt);
 }

--- a/StellarWallet.Application/Interfaces/ITransactionService.cs
+++ b/StellarWallet.Application/Interfaces/ITransactionService.cs
@@ -2,7 +2,6 @@
 using StellarWallet.Application.Dtos.Responses;
 using StellarWallet.Domain.Entities;
 using StellarWallet.Domain.Errors;
-using StellarWallet.Domain.Interfaces.Result;
 using StellarWallet.Domain.Result;
 
 namespace StellarWallet.Application.Interfaces;

--- a/StellarWallet.Application/Interfaces/ITransactionService.cs
+++ b/StellarWallet.Application/Interfaces/ITransactionService.cs
@@ -5,14 +5,13 @@ using StellarWallet.Domain.Errors;
 using StellarWallet.Domain.Interfaces.Result;
 using StellarWallet.Domain.Result;
 
-namespace StellarWallet.Application.Interfaces
+namespace StellarWallet.Application.Interfaces;
+
+public interface ITransactionService
 {
-    public interface ITransactionService
-    {
-        public Task<Result<BlockchainAccount, CustomError>> CreateAccount(string jwt);
-        public Task<Result<bool, CustomError>> SendPayment(SendPaymentDto sendPaymentDto, string jwt);
-        public Task<Result<TransactionsDto, CustomError>> GetTransaction(string jwt, int pageNumber, int pageSize);
-        public Task<Result<bool, CustomError>> GetTestFunds(string publicKey);
-        public Task<Result<FoundBalancesDto, CustomError>> GetBalances(GetBalancesDto getBalancesDto);
-    }
+    public Task<Result<BlockchainAccount, CustomError>> CreateAccount(string jwt);
+    public Task<Result<bool, CustomError>> SendPayment(SendPaymentDto sendPaymentDto, string jwt);
+    public Task<Result<TransactionsDto, CustomError>> GetTransaction(string jwt, int pageNumber, int pageSize);
+    public Task<Result<bool, CustomError>> GetTestFunds(string publicKey);
+    public Task<Result<FoundBalancesDto, CustomError>> GetBalances(GetBalancesDto getBalancesDto);
 }

--- a/StellarWallet.Application/Interfaces/IUserContactService.cs
+++ b/StellarWallet.Application/Interfaces/IUserContactService.cs
@@ -3,13 +3,12 @@ using StellarWallet.Application.Dtos.Responses;
 using StellarWallet.Domain.Errors;
 using StellarWallet.Domain.Result;
 
-namespace StellarWallet.Application.Interfaces
+namespace StellarWallet.Application.Interfaces;
+
+public interface IUserContactService
 {
-    public interface IUserContactService
-    {
-        Task<Result<IEnumerable<UserContactsDto>, CustomError>> GetAll(int id, string jwt);
-        Task<Result<bool, CustomError>> Add(AddContactDto userContact, string jwt);
-        Task<Result<bool, CustomError>> Update(UpdateContactDto userContact);
-        Task<Result<bool, CustomError>> Delete(int id);
-    }
+    Task<Result<IEnumerable<UserContactsDto>, CustomError>> GetAll(int id, string jwt);
+    Task<Result<bool, CustomError>> Add(AddContactDto userContact, string jwt);
+    Task<Result<bool, CustomError>> Update(UpdateContactDto userContact);
+    Task<Result<bool, CustomError>> Delete(int id);
 }

--- a/StellarWallet.Application/Interfaces/IUserService.cs
+++ b/StellarWallet.Application/Interfaces/IUserService.cs
@@ -3,15 +3,14 @@ using StellarWallet.Application.Dtos.Responses;
 using StellarWallet.Domain.Errors;
 using StellarWallet.Domain.Result;
 
-namespace StellarWallet.Application.Interfaces
+namespace StellarWallet.Application.Interfaces;
+
+public interface IUserService
 {
-    public interface IUserService
-    {
-        Task<Result<IEnumerable<UserDto>, CustomError>> GetAll();
-        Task<Result<UserDto, CustomError>> GetById(int id, string jwt);
-        Task<Result<LoggedDto, CustomError>> Add(UserCreationDto user);
-        Task<Result<bool, CustomError>> Update(UserUpdateDto user, string jwt);
-        Task<Result<bool, CustomError>> Delete(int id, string jwt);
-        Task<Result<bool, CustomError>> AddWallet(AddWalletDto wallet, string jwt);
-    }
+    Task<Result<IEnumerable<UserDto>, CustomError>> GetAll();
+    Task<Result<UserDto, CustomError>> GetById(int id, string jwt);
+    Task<Result<LoggedDto, CustomError>> Add(UserCreationDto user);
+    Task<Result<bool, CustomError>> Update(UserUpdateDto user, string jwt);
+    Task<Result<bool, CustomError>> Delete(int id, string jwt);
+    Task<Result<bool, CustomError>> AddWallet(AddWalletDto wallet, string jwt);
 }

--- a/StellarWallet.Application/Mappers/AutoMapperProfile.cs
+++ b/StellarWallet.Application/Mappers/AutoMapperProfile.cs
@@ -3,17 +3,16 @@ using StellarWallet.Application.Dtos.Requests;
 using StellarWallet.Application.Dtos.Responses;
 using StellarWallet.Domain.Entities;
 
-namespace StellarWallet.Application.Mappers
+namespace StellarWallet.Application.Mappers;
+
+public class AutoMapperProfile : Profile
 {
-    public class AutoMapperProfile : Profile
+    public AutoMapperProfile()
     {
-        public AutoMapperProfile()
-        {
-            CreateMap<User, UserDto>();
-            CreateMap<UserCreationDto, User>();
-            CreateMap<UserUpdateDto, User>();
-            CreateMap<UserContact, UserContactsDto>();
-            CreateMap<BlockchainAccount, BlockchainAccountDto>();
-        }
+        CreateMap<User, UserDto>();
+        CreateMap<UserCreationDto, User>();
+        CreateMap<UserUpdateDto, User>();
+        CreateMap<UserContact, UserContactsDto>();
+        CreateMap<BlockchainAccount, BlockchainAccountDto>();
     }
 }

--- a/StellarWallet.Application/Services/AuthService.cs
+++ b/StellarWallet.Application/Services/AuthService.cs
@@ -7,66 +7,65 @@ using StellarWallet.Domain.Interfaces.Persistence;
 using StellarWallet.Domain.Interfaces.Services;
 using StellarWallet.Domain.Result;
 
-namespace StellarWallet.Application.Services
+namespace StellarWallet.Application.Services;
+
+public class AuthService(IJwtService jwtService, IEncryptionService encryptionService, IUnitOfWork unitOfWork) : IAuthService
 {
-    public class AuthService(IJwtService jwtService, IEncryptionService encryptionService, IUnitOfWork unitOfWork) : IAuthService
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+    private readonly IJwtService _jwtService = jwtService;
+    private readonly IEncryptionService _encryptionService = encryptionService;
+    private readonly CustomError _userNotFoundError = CustomError.NotFound("User not found");
+
+    public async Task<Result<LoggedDto, CustomError>> Login(LoginDto loginDto)
     {
-        private readonly IUnitOfWork _unitOfWork = unitOfWork;
-        private readonly IJwtService _jwtService = jwtService;
-        private readonly IEncryptionService _encryptionService = encryptionService;
-        private readonly CustomError _userNotFoundError = CustomError.NotFound("User not found");
-
-        public async Task<Result<LoggedDto, CustomError>> Login(LoginDto loginDto)
+        var user = await _unitOfWork.User.GetBy(nameof(User.Email), loginDto.Email);
+        if (user is null)
         {
-            User? user = await _unitOfWork.User.GetBy(nameof(User.Email), loginDto.Email);
-            if (user is null)
-            {
-                return _userNotFoundError;
-            }
-
-            if (!_encryptionService.Verify(loginDto.Password, user.Password))
-            {
-                return CustomError.Unauthorized();
-            }
-
-            var createdTokenResponse = _jwtService.CreateToken(user.Email, user.Role);
-
-            if (!createdTokenResponse.IsSuccess)
-            {
-                return CustomError.InternalError(createdTokenResponse.Error.Message);
-            }
-
-            var createdToken = createdTokenResponse.Value;
-
-            return new LoggedDto(createdTokenResponse.IsSuccess, createdToken, user.PublicKey);
+            return _userNotFoundError;
         }
 
-        public Result<bool, CustomError> AuthenticateEmail(string jwt, string email)
+        if (!_encryptionService.Verify(loginDto.Password, user.Password))
         {
-            var jwtEmailDecoding = _jwtService.DecodeToken(jwt);
-
-            if (!jwtEmailDecoding.IsSuccess)
-            {
-                return CustomError.InternalError(jwtEmailDecoding.Error.Message);
-            }
-
-            var jwtEmail = jwtEmailDecoding.Value;
-
-            return jwtEmail.Equals(email);
+            return CustomError.Unauthorized();
         }
 
-        public async Task<Result<bool, CustomError>> AuthenticateToken(string jwt)
+        var createdTokenResponse = _jwtService.CreateToken(user.Email, user.Role);
+
+        if (!createdTokenResponse.IsSuccess)
         {
-            var jwtEmailResponse = _jwtService.DecodeToken(jwt);
-
-            if (!jwtEmailResponse.IsSuccess)
-            {
-                return CustomError.InternalError(jwtEmailResponse.Error.Message);
-            }
-
-            var email = jwtEmailResponse.Value;
-
-            return await _unitOfWork.User.GetBy(nameof(User.Email), email) is not null;
+            return CustomError.InternalError(createdTokenResponse.Error.Message);
         }
+
+        var createdToken = createdTokenResponse.Value;
+
+        return new LoggedDto(createdTokenResponse.IsSuccess, createdToken, user.PublicKey);
+    }
+
+    public Result<bool, CustomError> AuthenticateEmail(string jwt, string email)
+    {
+        var jwtEmailDecoding = _jwtService.DecodeToken(jwt);
+
+        if (!jwtEmailDecoding.IsSuccess)
+        {
+            return CustomError.InternalError(jwtEmailDecoding.Error.Message);
+        }
+
+        var jwtEmail = jwtEmailDecoding.Value;
+
+        return jwtEmail.Equals(email);
+    }
+
+    public async Task<Result<bool, CustomError>> AuthenticateToken(string jwt)
+    {
+        var jwtEmailResponse = _jwtService.DecodeToken(jwt);
+
+        if (!jwtEmailResponse.IsSuccess)
+        {
+            return CustomError.InternalError(jwtEmailResponse.Error.Message);
+        }
+
+        var email = jwtEmailResponse.Value;
+
+        return await _unitOfWork.User.GetBy(nameof(User.Email), email) is not null;
     }
 }

--- a/StellarWallet.Application/Services/TransactionService.cs
+++ b/StellarWallet.Application/Services/TransactionService.cs
@@ -5,10 +5,8 @@ using StellarWallet.Application.Utilities;
 using StellarWallet.Domain.Entities;
 using StellarWallet.Domain.Errors;
 using StellarWallet.Domain.Interfaces.Persistence;
-using StellarWallet.Domain.Interfaces.Result;
 using StellarWallet.Domain.Interfaces.Services;
 using StellarWallet.Domain.Result;
-using StellarWallet.Domain.Structs;
 
 namespace StellarWallet.Application.Services;
 

--- a/StellarWallet.Application/Services/TransactionService.cs
+++ b/StellarWallet.Application/Services/TransactionService.cs
@@ -10,135 +10,134 @@ using StellarWallet.Domain.Interfaces.Services;
 using StellarWallet.Domain.Result;
 using StellarWallet.Domain.Structs;
 
-namespace StellarWallet.Application.Services
+namespace StellarWallet.Application.Services;
+
+public class TransactionService(IBlockchainService blockchainService, IJwtService jwtService, IAuthService authService, IUnitOfWork unitOfWork) : ITransactionService
 {
-    public class TransactionService(IBlockchainService blockchainService, IJwtService jwtService, IAuthService authService, IUnitOfWork unitOfWork) : ITransactionService
+    private readonly IBlockchainService _blockchainService = blockchainService;
+    private readonly IJwtService _jwtService = jwtService;
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+    private readonly IAuthService _authService = authService;
+    private readonly CustomError _userNotFoundError = CustomError.NotFound("User not found");
+
+    public async Task<Result<BlockchainAccount, CustomError>> CreateAccount(string jwt)
     {
-        private readonly IBlockchainService _blockchainService = blockchainService;
-        private readonly IJwtService _jwtService = jwtService;
-        private readonly IUnitOfWork _unitOfWork = unitOfWork;
-        private readonly IAuthService _authService = authService;
-        private readonly CustomError _userNotFoundError = CustomError.NotFound("User not found");
-
-        public async Task<Result<BlockchainAccount, CustomError>> CreateAccount(string jwt)
+        var userEmail = _jwtService.DecodeToken(jwt);
+        if (!userEmail.IsSuccess)
         {
-            var userEmail = _jwtService.DecodeToken(jwt);
-            if (!userEmail.IsSuccess)
-            {
-                return CustomError.Unauthorized();
-            }
-
-            User? user = await _unitOfWork.User.GetBy(nameof(User.Email), userEmail.Value);
-            if (user is null)
-            {
-                return _userNotFoundError;
-            }
-
-            return _blockchainService.CreateAccount(user.Id);
+            return CustomError.Unauthorized();
         }
 
-        public async Task<Result<bool, CustomError>> SendPayment(SendPaymentDto sendPaymentDto, string jwt)
+        var user = await _unitOfWork.User.GetBy(nameof(User.Email), userEmail.Value);
+        if (user is null)
         {
-            var userEmail = _jwtService.DecodeToken(jwt);
-            User? user = await _unitOfWork.User.GetBy(nameof(User.Email), userEmail.Value);
-
-            if (user is null)
-            {
-                return _userNotFoundError;
-            }
-
-            var isAnAuthorizedUser = _authService.AuthenticateEmail(jwt, userEmail.Value);
-            if (!isAnAuthorizedUser.IsSuccess)
-            {
-                return CustomError.Unauthorized();
-            }
-
-            var transactionResponse = await _blockchainService.SendPayment(user.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), sendPaymentDto.AssetIssuer, sendPaymentDto.AssetCode, sendPaymentDto.Memo ?? String.Empty);
-
-            bool transactionCompleted = transactionResponse.IsSuccess;
-
-            if (!transactionCompleted)
-            {
-                return CustomError.ExternalServiceError(transactionResponse?.Error?.Message);
-            }
-
-            return transactionCompleted;
+            return _userNotFoundError;
         }
 
-        public async Task<Result<TransactionsDto, CustomError>> GetTransaction(string jwt, int pageNumber, int pageSize)
+        return _blockchainService.CreateAccount(user.Id);
+    }
+
+    public async Task<Result<bool, CustomError>> SendPayment(SendPaymentDto sendPaymentDto, string jwt)
+    {
+        var userEmail = _jwtService.DecodeToken(jwt);
+        var user = await _unitOfWork.User.GetBy(nameof(User.Email), userEmail.Value);
+
+        if (user is null)
         {
-            var userEmailDecoding = _jwtService.DecodeToken(jwt);
-
-            if (!userEmailDecoding.IsSuccess)
-            {
-                return Result<TransactionsDto, CustomError>.Failure(CustomError.Unauthorized());
-            }
-
-            User? user = await _unitOfWork.User.GetBy(nameof(User.Email), userEmailDecoding.Value);
-
-            if (user is null)
-            {
-                return _userNotFoundError;
-            }
-
-            var isAnAuthorizedUser = _authService.AuthenticateEmail(jwt, userEmailDecoding.Value);
-            if (!isAnAuthorizedUser.IsSuccess)
-            {
-                CustomError.Unauthorized();
-            }
-
-            var getPaymentsResponse = await _blockchainService.GetPayments(user.PublicKey);
-
-            if (!getPaymentsResponse.IsSuccess)
-            {
-                return CustomError.ExternalServiceError(getPaymentsResponse.Error.Message);
-            }
-
-            BlockchainPayment[] allPayments = getPaymentsResponse.Value;
-
-            List<BlockchainPayment> paginatedPayments = allPayments
-                .Skip((pageNumber - 1) * pageSize)
-                .Take(pageSize)
-                .ToList();
-
-            var totalPages = Paginate.GetTotalPages(allPayments.Length, pageSize);
-
-            TransactionsDto paginatedPaymentsDto = new(paginatedPayments, totalPages);
-
-            return Result<TransactionsDto, CustomError>.Success(paginatedPaymentsDto);
+            return _userNotFoundError;
         }
 
-        public async Task<Result<bool, CustomError>> GetTestFunds(string publicKey)
+        var isAnAuthorizedUser = _authService.AuthenticateEmail(jwt, userEmail.Value);
+        if (!isAnAuthorizedUser.IsSuccess)
         {
-            var getTestFundsResponse = await _blockchainService.GetTestFunds(publicKey);
-            if (!getTestFundsResponse.IsSuccess)
-            {
-                return CustomError.ExternalServiceError(getTestFundsResponse.Error.Message);
-            }
-
-            return getTestFundsResponse.Value;
+            return CustomError.Unauthorized();
         }
 
-        public async Task<Result<FoundBalancesDto, CustomError>> GetBalances(GetBalancesDto getBalancesDto)
+        var transactionResponse = await _blockchainService.SendPayment(user.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), sendPaymentDto.AssetIssuer, sendPaymentDto.AssetCode, sendPaymentDto.Memo ?? string.Empty);
+
+        var transactionCompleted = transactionResponse.IsSuccess;
+
+        if (!transactionCompleted)
         {
-            var getBalancesResponse = await _blockchainService.GetBalances(getBalancesDto.PublicKey);
-
-            if (!getBalancesResponse.IsSuccess)
-            {
-                return CustomError.ExternalServiceError(getBalancesResponse.Error.Message);
-            }
-
-            List<AccountBalances> balances = getBalancesResponse.Value;
-
-            if (getBalancesDto.FilterZeroBalances)
-            {
-                balances = balances.Where(balance => balance.Amount != "0.0000000").ToList();
-            }
-
-            int totalPages = Paginate.GetTotalPages(balances.Count, getBalancesDto.PageSize);
-            var paginatedBalances = Paginate.PaginateQuery<AccountBalances>(balances, getBalancesDto.PageNumber, getBalancesDto.PageSize).ToList();
-
-            return new FoundBalancesDto(paginatedBalances, totalPages);
+            return CustomError.ExternalServiceError(transactionResponse?.Error?.Message);
         }
+
+        return transactionCompleted;
+    }
+
+    public async Task<Result<TransactionsDto, CustomError>> GetTransaction(string jwt, int pageNumber, int pageSize)
+    {
+        var userEmailDecoding = _jwtService.DecodeToken(jwt);
+
+        if (!userEmailDecoding.IsSuccess)
+        {
+            return Result<TransactionsDto, CustomError>.Failure(CustomError.Unauthorized());
+        }
+
+        var user = await _unitOfWork.User.GetBy(nameof(User.Email), userEmailDecoding.Value);
+
+        if (user is null)
+        {
+            return _userNotFoundError;
+        }
+
+        var isAnAuthorizedUser = _authService.AuthenticateEmail(jwt, userEmailDecoding.Value);
+        if (!isAnAuthorizedUser.IsSuccess)
+        {
+            CustomError.Unauthorized();
+        }
+
+        var getPaymentsResponse = await _blockchainService.GetPayments(user.PublicKey);
+
+        if (!getPaymentsResponse.IsSuccess)
+        {
+            return CustomError.ExternalServiceError(getPaymentsResponse.Error.Message);
+        }
+
+        var allPayments = getPaymentsResponse.Value;
+
+        var paginatedPayments = allPayments
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .ToList();
+
+        var totalPages = Paginate.GetTotalPages(allPayments.Length, pageSize);
+
+        TransactionsDto paginatedPaymentsDto = new(paginatedPayments, totalPages);
+
+        return Result<TransactionsDto, CustomError>.Success(paginatedPaymentsDto);
+    }
+
+    public async Task<Result<bool, CustomError>> GetTestFunds(string publicKey)
+    {
+        var getTestFundsResponse = await _blockchainService.GetTestFunds(publicKey);
+        if (!getTestFundsResponse.IsSuccess)
+        {
+            return CustomError.ExternalServiceError(getTestFundsResponse.Error.Message);
+        }
+
+        return getTestFundsResponse.Value;
+    }
+
+    public async Task<Result<FoundBalancesDto, CustomError>> GetBalances(GetBalancesDto getBalancesDto)
+    {
+        var getBalancesResponse = await _blockchainService.GetBalances(getBalancesDto.PublicKey);
+
+        if (!getBalancesResponse.IsSuccess)
+        {
+            return CustomError.ExternalServiceError(getBalancesResponse.Error.Message);
+        }
+
+        var balances = getBalancesResponse.Value;
+
+        if (getBalancesDto.FilterZeroBalances)
+        {
+            balances = balances.Where(balance => balance.Amount != "0.0000000").ToList();
+        }
+
+        var totalPages = Paginate.GetTotalPages(balances.Count, getBalancesDto.PageSize);
+        var paginatedBalances = Paginate.PaginateQuery(balances, getBalancesDto.PageNumber, getBalancesDto.PageSize).ToList();
+
+        return new FoundBalancesDto(paginatedBalances, totalPages);
     }
 }

--- a/StellarWallet.Application/Services/UserContactService.cs
+++ b/StellarWallet.Application/Services/UserContactService.cs
@@ -8,115 +8,116 @@ using StellarWallet.Domain.Interfaces.Persistence;
 using StellarWallet.Domain.Interfaces.Services;
 using StellarWallet.Domain.Result;
 
-namespace StellarWallet.Application.Services
+namespace StellarWallet.Application.Services;
+
+public class UserContactService(IUserService userService, IJwtService jwtService, IMapper mapper, IAuthService authService, IUnitOfWork unitOfWork) : IUserContactService
 {
-    public class UserContactService(IUserService userService, IJwtService jwtService, IMapper mapper, IAuthService authService, IUnitOfWork unitOfWork) : IUserContactService
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+    private readonly IUserService _userService = userService;
+    private readonly IJwtService _jwtService = jwtService;
+    private readonly IAuthService _authService = authService;
+    private readonly IMapper _mapper = mapper;
+    private readonly CustomError _userNotFoundError = CustomError.NotFound("User not found");
+
+    public async Task<Result<bool, CustomError>> Add(AddContactDto userContact, string jwt)
     {
-        private readonly IUnitOfWork _unitOfWork = unitOfWork;
-        private readonly IUserService _userService = userService;
-        private readonly IJwtService _jwtService = jwtService;
-        private readonly IAuthService _authService = authService;
-        private readonly IMapper _mapper = mapper;
-        private readonly CustomError _userNotFoundError = CustomError.NotFound("User not found");
+        var userEmailDecoding = _jwtService.DecodeToken(jwt);
 
-        public async Task<Result<bool, CustomError>> Add(AddContactDto userContact, string jwt)
+        if (!userEmailDecoding.IsSuccess)
         {
-            var userEmailDecoding = _jwtService.DecodeToken(jwt);
+            return CustomError.InternalError(userEmailDecoding.Error.Message);
+        }
 
-            if (!userEmailDecoding.IsSuccess)
+        var foundUser = await _unitOfWork.User.GetBy(nameof(User.Email), userEmailDecoding.Value);
+
+        if (foundUser is null)
+        {
+            return _userNotFoundError;
+        }
+
+        var isValidEmail = _authService.AuthenticateEmail(jwt, foundUser.Email);
+
+        if (!isValidEmail.IsSuccess)
+        {
+            return isValidEmail.Error;
+        }
+
+        if (foundUser.UserContacts?.Count >= 10)
+        {
+            return CustomError.Conflict("User has reached the maximum number of contacts");
+        }
+
+        if (foundUser.UserContacts is not null)
+        {
+            foreach (var contact in foundUser.UserContacts)
             {
-                return CustomError.InternalError(userEmailDecoding.Error.Message);
-            }
-
-            User? foundUser = await _unitOfWork.User.GetBy(nameof(User.Email), userEmailDecoding.Value);
-
-            if (foundUser is null)
-            {
-                return _userNotFoundError;
-            }
-
-            var isValidEmail = _authService.AuthenticateEmail(jwt, foundUser.Email);
-
-            if (!isValidEmail.IsSuccess)
-            {
-                return isValidEmail.Error;
-            }
-
-            if (foundUser.UserContacts?.Count >= 10)
-            {
-                return CustomError.Conflict("User has reached the maximum number of contacts");
-            }
-
-            if (foundUser.UserContacts is not null)
-                foreach (UserContact contact in foundUser.UserContacts)
+                if (contact.Alias == userContact.Alias)
                 {
-                    if (contact.Alias == userContact.Alias)
-                    {
-                        return CustomError.Conflict("Contact already exists");
-                    }
+                    return CustomError.Conflict("Contact already exists");
                 }
-
-            await _unitOfWork.UserContact.Add(new UserContact(userContact.Alias, foundUser.Id, userContact.PublicKey));
-
-            return isValidEmail.IsSuccess;
+            }
         }
 
-        public async Task<Result<bool, CustomError>> Delete(int id)
+        await _unitOfWork.UserContact.Add(new UserContact(userContact.Alias, foundUser.Id, userContact.PublicKey));
+
+        return isValidEmail.IsSuccess;
+    }
+
+    public async Task<Result<bool, CustomError>> Delete(int id)
+    {
+        var userContactFound = await _unitOfWork.UserContact.GetById(id);
+
+        if (userContactFound is null)
         {
-            UserContact? userContactFound = await _unitOfWork.UserContact.GetById(id);
-
-            if (userContactFound is null)
-            {
-                CustomError.NotFound("Contact not found");
-            }
-
-            await _unitOfWork.UserContact.Delete(id);
-
-            return true;
+            CustomError.NotFound("Contact not found");
         }
 
-        public async Task<Result<IEnumerable<UserContactsDto>, CustomError>> GetAll(int id, string jwt)
+        await _unitOfWork.UserContact.Delete(id);
+
+        return true;
+    }
+
+    public async Task<Result<IEnumerable<UserContactsDto>, CustomError>> GetAll(int id, string jwt)
+    {
+        var foundUser = await _userService.GetById(id, jwt);
+        if (foundUser is null)
         {
-            var foundUser = await _userService.GetById(id, jwt);
-            if (foundUser is null)
-            {
-                return _userNotFoundError;
-            }
-
-            var IsValidEmail = _authService.AuthenticateEmail(jwt, foundUser.Value.Email);
-
-            if (!IsValidEmail.IsSuccess)
-            {
-                return CustomError.Unauthorized();
-            }
-
-            IEnumerable<UserContact> userContacts = await _unitOfWork.UserContact.GetAll(uc => uc.UserId == id);
-
-            if (userContacts is null)
-            {
-                return CustomError.NotFound("Contacts not found");
-            }
-
-            return _mapper.Map<UserContactsDto[]>(userContacts);
+            return _userNotFoundError;
         }
 
-        public async Task<Result<bool, CustomError>> Update(UpdateContactDto userContact)
+        var IsValidEmail = _authService.AuthenticateEmail(jwt, foundUser.Value.Email);
+
+        if (!IsValidEmail.IsSuccess)
         {
-            UserContact? foundUserContact = await _unitOfWork.UserContact.GetById(userContact.Id);
-
-            if (foundUserContact is null)
-            {
-                return CustomError.NotFound("Contact not found");
-            }
-
-            if (userContact.Alias is not null)
-            {
-                foundUserContact.Alias = userContact.Alias;
-            }
-
-            _unitOfWork.UserContact.Update(foundUserContact);
-
-            return true;
+            return CustomError.Unauthorized();
         }
+
+        var userContacts = await _unitOfWork.UserContact.GetAll(uc => uc.UserId == id);
+
+        if (userContacts is null)
+        {
+            return CustomError.NotFound("Contacts not found");
+        }
+
+        return _mapper.Map<UserContactsDto[]>(userContacts);
+    }
+
+    public async Task<Result<bool, CustomError>> Update(UpdateContactDto userContact)
+    {
+        var foundUserContact = await _unitOfWork.UserContact.GetById(userContact.Id);
+
+        if (foundUserContact is null)
+        {
+            return CustomError.NotFound("Contact not found");
+        }
+
+        if (userContact.Alias is not null)
+        {
+            foundUserContact.Alias = userContact.Alias;
+        }
+
+        _unitOfWork.UserContact.Update(foundUserContact);
+
+        return true;
     }
 }

--- a/StellarWallet.Application/Services/UserService.cs
+++ b/StellarWallet.Application/Services/UserService.cs
@@ -7,7 +7,6 @@ using StellarWallet.Domain.Errors;
 using StellarWallet.Domain.Interfaces.Persistence;
 using StellarWallet.Domain.Interfaces.Services;
 using StellarWallet.Domain.Result;
-using StellarWallet.Domain.Structs;
 
 namespace StellarWallet.Application.Services;
 

--- a/StellarWallet.Application/Services/UserService.cs
+++ b/StellarWallet.Application/Services/UserService.cs
@@ -9,99 +9,122 @@ using StellarWallet.Domain.Interfaces.Services;
 using StellarWallet.Domain.Result;
 using StellarWallet.Domain.Structs;
 
-namespace StellarWallet.Application.Services
+namespace StellarWallet.Application.Services;
+
+public class UserService(IJwtService jwtService, IEncryptionService encryptionService, IMapper mapper, IBlockchainService stellarService, IBlockchainAccountRepository blockchainAccountRepository, IAuthService authService, IUnitOfWork unitOfWork
+    ) : IUserService
 {
-    public class UserService(IJwtService jwtService, IEncryptionService encryptionService, IMapper mapper, IBlockchainService stellarService, IBlockchainAccountRepository blockchainAccountRepository, IAuthService authService, IUnitOfWork unitOfWork
-        ) : IUserService
+    private readonly IJwtService _jwtService = jwtService;
+    private readonly IEncryptionService _encryptionService = encryptionService;
+    private readonly IBlockchainService _stellarService = stellarService;
+    private readonly IBlockchainAccountRepository _blockchainAccountRepository = blockchainAccountRepository;
+    private readonly IAuthService _authService = authService;
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+    private readonly IMapper _mapper = mapper;
+    private readonly CustomError _userNotFoundError = CustomError.NotFound("User not found");
+
+    public async Task<Result<IEnumerable<UserDto>, CustomError>> GetAll()
     {
-        private readonly IJwtService _jwtService = jwtService;
-        private readonly IEncryptionService _encryptionService = encryptionService;
-        private readonly IBlockchainService _stellarService = stellarService;
-        private readonly IBlockchainAccountRepository _blockchainAccountRepository = blockchainAccountRepository;
-        private readonly IAuthService _authService = authService;
-        private readonly IUnitOfWork _unitOfWork = unitOfWork;
-        private readonly IMapper _mapper = mapper;
-        private readonly CustomError _userNotFoundError = CustomError.NotFound("User not found");
-
-        public async Task<Result<IEnumerable<UserDto>, CustomError>> GetAll()
+        try
         {
-            try
-            {
-                IEnumerable<User> users = await _unitOfWork.User.GetAll();
-                return _mapper.Map<UserDto[]>(users);
-            }
-            catch (Exception e)
-            {
-                return CustomError.InternalError(e.Message);
-            }
+            var users = await _unitOfWork.User.GetAll();
+            return _mapper.Map<UserDto[]>(users);
+        }
+        catch (Exception e)
+        {
+            return CustomError.InternalError(e.Message);
+        }
+    }
+
+    public async Task<Result<UserDto, CustomError>> GetById(int id, string jwt)
+    {
+        var foundUser = await _unitOfWork.User.GetById(id);
+
+        if (foundUser is null)
+        {
+            return _userNotFoundError;
         }
 
-        public async Task<Result<UserDto, CustomError>> GetById(int id, string jwt)
+        var IsValidEmail = _authService.AuthenticateEmail(jwt, foundUser.Email);
+
+        if (!IsValidEmail.IsSuccess)
         {
-            User? foundUser = await _unitOfWork.User.GetById(id);
-
-            if (foundUser is null)
-            {
-                return _userNotFoundError;
-            }
-
-            var IsValidEmail = _authService.AuthenticateEmail(jwt, foundUser.Email);
-
-            if (!IsValidEmail.IsSuccess)
-            {
-                return CustomError.Forbidden();
-            }
-
-            return _mapper.Map<UserDto>(foundUser);
+            return CustomError.Forbidden();
         }
 
-        public async Task<Result<LoggedDto, CustomError>> Add(UserCreationDto user)
-        {
-            User? foundUser = await _unitOfWork.User.GetBy(nameof(User.Email), user.Email);
-            if (foundUser is not null)
-            {
-                return CustomError.Conflict("User already exists.");
-            }
+        return _mapper.Map<UserDto>(foundUser);
+    }
 
+    public async Task<Result<LoggedDto, CustomError>> Add(UserCreationDto user)
+    {
+        var foundUser = await _unitOfWork.User.GetBy(nameof(User.Email), user.Email);
+        if (foundUser is not null)
+        {
+            return CustomError.Conflict("User already exists.");
+        }
+
+        user.Password = _encryptionService.Encrypt(user.Password);
+
+        var account = _stellarService.CreateKeyPair().Value;
+        user.PublicKey = account.PublicKey;
+        user.SecretKey = account.SecretKey;
+
+        await _unitOfWork.User.Add(_mapper.Map<User>(user));
+
+        return new LoggedDto(true, null, user.PublicKey);
+    }
+
+    public async Task<Result<bool, CustomError>> Update(UserUpdateDto user, string jwt)
+    {
+        if (user.Password is not null)
+        {
             user.Password = _encryptionService.Encrypt(user.Password);
-
-            AccountKeyPair account = _stellarService.CreateKeyPair().Value;
-            user.PublicKey = account.PublicKey;
-            user.SecretKey = account.SecretKey;
-
-            await _unitOfWork.User.Add(_mapper.Map<User>(user));
-
-            return new LoggedDto(true, null, user.PublicKey);
         }
 
-        public async Task<Result<bool, CustomError>> Update(UserUpdateDto user, string jwt)
+        var foundUser = await _unitOfWork.User.GetById(user.Id);
+        if (foundUser is null)
         {
-            if (user.Password is not null)
-            {
-                user.Password = _encryptionService.Encrypt(user.Password);
-            }
-
-            User? foundUser = await _unitOfWork.User.GetById(user.Id);
-            if (foundUser is null)
-            {
-                return _userNotFoundError;
-            }
-
-            var IsValidEmail = _authService.AuthenticateEmail(jwt, foundUser.Email);
-
-            if (!IsValidEmail.IsSuccess)
-            {
-                return CustomError.Forbidden();
-            }
-
-            _unitOfWork.User.Update(_mapper.Map<User>(user));
-
-            return IsValidEmail.IsSuccess;
+            return _userNotFoundError;
         }
 
-        public async Task<Result<bool, CustomError>> Delete(int id, string jwt)
+        var IsValidEmail = _authService.AuthenticateEmail(jwt, foundUser.Email);
+
+        if (!IsValidEmail.IsSuccess)
         {
-            User? foundUser = await _unitOfWork.User.GetById(id);
+            return CustomError.Forbidden();
+        }
+
+        _unitOfWork.User.Update(_mapper.Map<User>(user));
+
+        return IsValidEmail.IsSuccess;
+    }
+
+    public async Task<Result<bool, CustomError>> Delete(int id, string jwt)
+    {
+        var foundUser = await _unitOfWork.User.GetById(id);
+        if (foundUser is null)
+        {
+            return _userNotFoundError;
+        }
+
+        var IsValidEmail = _authService.AuthenticateEmail(jwt, foundUser.Email);
+
+        if (!IsValidEmail.IsSuccess)
+        {
+            return IsValidEmail.Error;
+        }
+
+        await _unitOfWork.User.Delete(id);
+
+        return IsValidEmail.IsSuccess;
+    }
+
+    public async Task<Result<bool, CustomError>> AddWallet(AddWalletDto wallet, string jwt)
+    {
+        try
+        {
+            var email = _jwtService.DecodeToken(jwt);
+            var foundUser = await _unitOfWork.User.GetBy(nameof(User.Email), email.Value);
             if (foundUser is null)
             {
                 return _userNotFoundError;
@@ -114,59 +137,35 @@ namespace StellarWallet.Application.Services
                 return IsValidEmail.Error;
             }
 
-            await _unitOfWork.User.Delete(id);
+            if (foundUser.BlockchainAccounts is not null)
+            {
+                foreach (var account in foundUser.BlockchainAccounts)
+                {
+                    if (account.PublicKey == wallet.PublicKey)
+                    {
+                        return CustomError.Conflict("Wallet already exists.");
+                    }
+                }
 
-            return IsValidEmail.IsSuccess;
+                if (foundUser.BlockchainAccounts.Count >= 5)
+                {
+                    return CustomError.Conflict("User already has 5 wallets.");
+                }
+            }
+
+            BlockchainAccount newAccount = new(wallet.PublicKey, wallet.SecretKey, foundUser.Id)
+            {
+                User = foundUser
+            };
+
+            await _blockchainAccountRepository.Add(newAccount);
+            _unitOfWork.User.Update(foundUser);
+
+            return true;
         }
-
-        public async Task<Result<bool, CustomError>> AddWallet(AddWalletDto wallet, string jwt)
+        catch (Exception e)
         {
-            try
-            {
-                var email = _jwtService.DecodeToken(jwt);
-                User? foundUser = await _unitOfWork.User.GetBy(nameof(User.Email), email.Value);
-                if (foundUser is null)
-                {
-                    return _userNotFoundError;
-                }
-
-                var IsValidEmail = _authService.AuthenticateEmail(jwt, foundUser.Email);
-
-                if (!IsValidEmail.IsSuccess)
-                {
-                    return IsValidEmail.Error;
-                }
-
-                if (foundUser.BlockchainAccounts is not null)
-                {
-                    foreach (BlockchainAccount account in foundUser.BlockchainAccounts)
-                    {
-                        if (account.PublicKey == wallet.PublicKey)
-                        {
-                            return CustomError.Conflict("Wallet already exists.");
-                        }
-                    }
-
-                    if (foundUser.BlockchainAccounts.Count >= 5)
-                    {
-                        return CustomError.Conflict("User already has 5 wallets.");
-                    }
-                }
-
-                BlockchainAccount newAccount = new(wallet.PublicKey, wallet.SecretKey, foundUser.Id)
-                {
-                    User = foundUser
-                };
-
-                await _blockchainAccountRepository.Add(newAccount);
-                _unitOfWork.User.Update(foundUser);
-
-                return true;
-            }
-            catch (Exception e)
-            {
-                return CustomError.InternalError(e.Message);
-            }
+            return CustomError.InternalError(e.Message);
         }
     }
 }

--- a/StellarWallet.Application/StellarWallet.Application.csproj
+++ b/StellarWallet.Application/StellarWallet.Application.csproj
@@ -8,11 +8,18 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.3.0.106239">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-
     <ProjectReference Include="..\StellarWallet.Infrastructure\StellarWallet.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\.editorconfig" />
   </ItemGroup>
 
 </Project>

--- a/StellarWallet.Application/Utilities/Paginate.cs
+++ b/StellarWallet.Application/Utilities/Paginate.cs
@@ -1,22 +1,21 @@
-﻿namespace StellarWallet.Application.Utilities
+﻿namespace StellarWallet.Application.Utilities;
+
+public static class Paginate
 {
-    public static class Paginate
+    public static List<T> PaginateQuery<T>(List<T> query, int pageNumber, int pageSize)
     {
-        public static List<T> PaginateQuery<T>(List<T> query, int pageNumber, int pageSize)
-        {
-            ValidatePageNumber(pageNumber, GetTotalPages(query.Count(), pageSize));
-            return query.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToList();
-        }
+        ValidatePageNumber(pageNumber, GetTotalPages(query.Count(), pageSize));
+        return query.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToList();
+    }
 
-        public static int GetTotalPages(int totalItems, int pageSize)
-        {
-            return (int)Math.Ceiling(totalItems / (double)pageSize);
-        }
+    public static int GetTotalPages(int totalItems, int pageSize)
+    {
+        return (int)Math.Ceiling(totalItems / (double)pageSize);
+    }
 
-        private static void ValidatePageNumber(int pageNumber, int totalPages)
-        {
-            if (pageNumber <= 0 || pageNumber > totalPages)
-                throw new Exception("Invalid page number.");
-        }
+    private static void ValidatePageNumber(int pageNumber, int totalPages)
+    {
+        if (pageNumber <= 0 || pageNumber > totalPages)
+            throw new Exception("Invalid page number.");
     }
 }

--- a/StellarWallet.Application/Utilities/Paginate.cs
+++ b/StellarWallet.Application/Utilities/Paginate.cs
@@ -4,7 +4,7 @@ public static class Paginate
 {
     public static List<T> PaginateQuery<T>(List<T> query, int pageNumber, int pageSize)
     {
-        ValidatePageNumber(pageNumber, GetTotalPages(query.Count(), pageSize));
+        ValidatePageNumber(pageNumber, GetTotalPages(query.Count, pageSize));
         return query.Skip((pageNumber - 1) * pageSize).Take(pageSize).ToList();
     }
 
@@ -16,6 +16,8 @@ public static class Paginate
     private static void ValidatePageNumber(int pageNumber, int totalPages)
     {
         if (pageNumber <= 0 || pageNumber > totalPages)
-            throw new Exception("Invalid page number.");
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageNumber), "Invalid page number.");
+        }
     }
 }

--- a/StellarWallet.Domain/Entities/BlockchainAccount.cs
+++ b/StellarWallet.Domain/Entities/BlockchainAccount.cs
@@ -1,28 +1,27 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
-namespace StellarWallet.Domain.Entities
+namespace StellarWallet.Domain.Entities;
+
+public class BlockchainAccount(string PublicKey, string SecretKey, int userId)
 {
-    public class BlockchainAccount(string PublicKey, string SecretKey, int userId)
-    {
-        [Key]
-        public int Id { get; private set; }
+    [Key]
+    public int Id { get; private set; }
 
-        [Required(ErrorMessage = "Public key is required")]
-        [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
-        public string PublicKey { get; set; } = PublicKey;
+    [Required(ErrorMessage = "Public key is required")]
+    [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters")]
+    public string PublicKey { get; set; } = PublicKey;
 
-        [Required(ErrorMessage = "Secret key is required")]
-        [StringLength(56, MinimumLength = 56, ErrorMessage = "Secret key must have 56 characters")]
-        public string SecretKey { get; set; } = SecretKey;
+    [Required(ErrorMessage = "Secret key is required")]
+    [StringLength(56, MinimumLength = 56, ErrorMessage = "Secret key must have 56 characters")]
+    public string SecretKey { get; set; } = SecretKey;
 
-        [Required(ErrorMessage = "User id is required")]
-        public int UserId { get; set; } = userId;
+    [Required(ErrorMessage = "User id is required")]
+    public int UserId { get; set; } = userId;
 
-        [JsonIgnore]
-        public User? User { get; set; } = null;
+    [JsonIgnore]
+    public User? User { get; set; } = null;
 
-        [JsonIgnore]
-        public UserContact? UserContact { get; set; } = null;
-    }
+    [JsonIgnore]
+    public UserContact? UserContact { get; set; } = null;
 }

--- a/StellarWallet.Domain/Entities/User.cs
+++ b/StellarWallet.Domain/Entities/User.cs
@@ -1,43 +1,42 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace StellarWallet.Domain.Entities
+namespace StellarWallet.Domain.Entities;
+
+public class User(string name, string lastName, string email, string password, string publicKey, string secretKey, string role = "user")
 {
-    public class User(string name, string lastName, string email, string password, string publicKey, string secretKey, string role = "user")
-    {
-        [Key]
-        public int Id { get; private set; }
+    [Key]
+    public int Id { get; private set; }
 
-        [Required(ErrorMessage = "Name is required")]
-        [StringLength(50, MinimumLength = 3, ErrorMessage = "Name must have a maximum of 50 characters and a minimun of 3")]
-        [RegularExpression(@"^[a-zA-Z''-'\s]{3,50}$", ErrorMessage = "Special characters are not allowed.")]
-        public string Name { get; set; } = name;
+    [Required(ErrorMessage = "Name is required")]
+    [StringLength(50, MinimumLength = 3, ErrorMessage = "Name must have a maximum of 50 characters and a minimun of 3")]
+    [RegularExpression(@"^[a-zA-Z''-'\s]{3,50}$", ErrorMessage = "Special characters are not allowed.")]
+    public string Name { get; set; } = name;
 
-        [Required(ErrorMessage = "Lastname is required")]
-        [StringLength(50, MinimumLength = 3, ErrorMessage = "Lastname must have a maximum of 50 characters and a minimun of 3")]
-        [RegularExpression(@"^[a-zA-Z''-'\s]{3,50}$", ErrorMessage = "Special characters are not allowed.")]
-        public string LastName { get; set; } = lastName;
+    [Required(ErrorMessage = "Lastname is required")]
+    [StringLength(50, MinimumLength = 3, ErrorMessage = "Lastname must have a maximum of 50 characters and a minimun of 3")]
+    [RegularExpression(@"^[a-zA-Z''-'\s]{3,50}$", ErrorMessage = "Special characters are not allowed.")]
+    public string LastName { get; set; } = lastName;
 
-        [Required(ErrorMessage = "Email is required")]
-        [EmailAddress(ErrorMessage = "Invalid email")]
-        public string Email { get; set; } = email;
+    [Required(ErrorMessage = "Email is required")]
+    [EmailAddress(ErrorMessage = "Invalid email")]
+    public string Email { get; set; } = email;
 
-        [Required(ErrorMessage = "Password is required")]
-        public string Password { get; set; } = password;
+    [Required(ErrorMessage = "Password is required")]
+    public string Password { get; set; } = password;
 
-        [Required(ErrorMessage = "Public key is required")]
-        [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters.")]
-        [RegularExpression(@"^[a-zA-Z''-'\s]{56}$", ErrorMessage = "Special characters are not allowed.")]
-        public string PublicKey { get; set; } = publicKey;
+    [Required(ErrorMessage = "Public key is required")]
+    [StringLength(56, MinimumLength = 56, ErrorMessage = "Public key must have 56 characters.")]
+    [RegularExpression(@"^[a-zA-Z''-'\s]{56}$", ErrorMessage = "Special characters are not allowed.")]
+    public string PublicKey { get; set; } = publicKey;
 
-        [Required(ErrorMessage = "Secret key is required")]
-        [StringLength(56, MinimumLength = 56, ErrorMessage = "Secret key must have a 56 characters.")]
-        [RegularExpression(@"^[a-zA-Z''-'\s]{56}$", ErrorMessage = "Special characters are not allowed.")]
-        public string SecretKey { get; set; } = secretKey;
+    [Required(ErrorMessage = "Secret key is required")]
+    [StringLength(56, MinimumLength = 56, ErrorMessage = "Secret key must have a 56 characters.")]
+    [RegularExpression(@"^[a-zA-Z''-'\s]{56}$", ErrorMessage = "Special characters are not allowed.")]
+    public string SecretKey { get; set; } = secretKey;
 
-        public string Role { get; set; } = role;
+    public string Role { get; set; } = role;
 
-        public ICollection<BlockchainAccount>? BlockchainAccounts { get; set; } = null;
+    public ICollection<BlockchainAccount>? BlockchainAccounts { get; set; } = null;
 
-        public ICollection<UserContact>? UserContacts { get; set; } = null;
-    }
+    public ICollection<UserContact>? UserContacts { get; set; } = null;
 }

--- a/StellarWallet.Domain/Entities/UserContact.cs
+++ b/StellarWallet.Domain/Entities/UserContact.cs
@@ -1,25 +1,24 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
-namespace StellarWallet.Domain.Entities
+namespace StellarWallet.Domain.Entities;
+
+public class UserContact(string alias, int userId, string publicKey)
 {
-    public class UserContact(string alias, int userId, string publicKey)
-    {
-        [Key]
-        public int Id { get; private set; }
+    [Key]
+    public int Id { get; private set; }
 
-        [Required(ErrorMessage = "Alias is required")]
-        [StringLength(50, MinimumLength = 3, ErrorMessage = "Alias must have a maximum of 50 characters and a minimum of 3")]
-        public string Alias { get; set; } = alias;
+    [Required(ErrorMessage = "Alias is required")]
+    [StringLength(50, MinimumLength = 3, ErrorMessage = "Alias must have a maximum of 50 characters and a minimum of 3")]
+    public string Alias { get; set; } = alias;
 
-        [Required(ErrorMessage = "PublicKey is requires")]
-        [Length(56, 56)]
-        public string PublicKey { get; set; } = publicKey;
+    [Required(ErrorMessage = "PublicKey is requires")]
+    [Length(56, 56)]
+    public string PublicKey { get; set; } = publicKey;
 
-        [Required(ErrorMessage = "User id is required")]
-        public int UserId { get; set; } = userId;
+    [Required(ErrorMessage = "User id is required")]
+    public int UserId { get; set; } = userId;
 
-        [JsonIgnore]
-        public User? User { get; set; } = null;
-    }
+    [JsonIgnore]
+    public User? User { get; set; } = null;
 }

--- a/StellarWallet.Domain/Errors/CustomError.cs
+++ b/StellarWallet.Domain/Errors/CustomError.cs
@@ -1,16 +1,15 @@
-﻿namespace StellarWallet.Domain.Errors
+﻿namespace StellarWallet.Domain.Errors;
+
+public class CustomError(string? errorMessage, ErrorType errorType, int errorCode)
 {
-    public class CustomError(string? errorMessage, ErrorType errorType, int errorCode)
-    {
-        public string? Message { get; set; } = errorMessage;
-        public ErrorType Type { get; set; } = errorType;
-        public int Code { get; set; } = errorCode;
-        public static CustomError NotFound(string? errorMessage = "Given parameter not found.") => new(errorMessage, ErrorType.NotFound, 404);
-        public static CustomError Invalid(string? errorMessage = "Invalid parameter.") => new(errorMessage, ErrorType.Invalid, 400);
-        public static CustomError Conflict(string? errorMessage = "Conflict with existing data.") => new(errorMessage, ErrorType.Conflict, 409);
-        public static CustomError ExternalServiceError(string? errorMessage = "External service error.") => new(errorMessage, ErrorType.ExternalServiceError, 500);
-        public static CustomError Unauthorized(string? errorMessage = "Unauthorized access.") => new(errorMessage, ErrorType.UnauthorizedError, 401);
-        public static CustomError InternalError(string? errorMessage = "Internal server error.") => new(errorMessage, ErrorType.InternalError, 500);
-        public static CustomError Forbidden(string? errorMessage = "Forbidden access.") => new(errorMessage, ErrorType.Forbidden, 403);
-    }
+    public string? Message { get; set; } = errorMessage;
+    public ErrorType Type { get; set; } = errorType;
+    public int Code { get; set; } = errorCode;
+    public static CustomError NotFound(string? errorMessage = "Given parameter not found.") => new(errorMessage, ErrorType.NotFound, 404);
+    public static CustomError Invalid(string? errorMessage = "Invalid parameter.") => new(errorMessage, ErrorType.Invalid, 400);
+    public static CustomError Conflict(string? errorMessage = "Conflict with existing data.") => new(errorMessage, ErrorType.Conflict, 409);
+    public static CustomError ExternalServiceError(string? errorMessage = "External service error.") => new(errorMessage, ErrorType.ExternalServiceError, 500);
+    public static CustomError Unauthorized(string? errorMessage = "Unauthorized access.") => new(errorMessage, ErrorType.UnauthorizedError, 401);
+    public static CustomError InternalError(string? errorMessage = "Internal server error.") => new(errorMessage, ErrorType.InternalError, 500);
+    public static CustomError Forbidden(string? errorMessage = "Forbidden access.") => new(errorMessage, ErrorType.Forbidden, 403);
 }

--- a/StellarWallet.Domain/Errors/ErrorType.cs
+++ b/StellarWallet.Domain/Errors/ErrorType.cs
@@ -1,13 +1,12 @@
-﻿namespace StellarWallet.Domain.Errors
+﻿namespace StellarWallet.Domain.Errors;
+
+public enum ErrorType
 {
-    public enum ErrorType
-    {
-        NotFound,
-        Invalid,
-        Conflict,
-        ExternalServiceError,
-        UnauthorizedError,
-        InternalError,
-        Forbidden
-    }
+    NotFound,
+    Invalid,
+    Conflict,
+    ExternalServiceError,
+    UnauthorizedError,
+    InternalError,
+    Forbidden
 }

--- a/StellarWallet.Domain/Interfaces/Persistence/IBlockchainAccountRepository.cs
+++ b/StellarWallet.Domain/Interfaces/Persistence/IBlockchainAccountRepository.cs
@@ -1,8 +1,7 @@
 ﻿using StellarWallet.Domain.Entities;
 
-namespace StellarWallet.Domain.Interfaces.Persistence
+namespace StellarWallet.Domain.Interfaces.Persistence;
+
+public interface IBlockchainAccountRepository : IRepository<BlockchainAccount>
 {
-    public interface IBlockchainAccountRepository : IRepository<BlockchainAccount>
-    {
-    }
 }

--- a/StellarWallet.Domain/Interfaces/Persistence/IRepository.cs
+++ b/StellarWallet.Domain/Interfaces/Persistence/IRepository.cs
@@ -1,13 +1,12 @@
 ﻿using System.Linq.Expressions;
 
-namespace StellarWallet.Domain.Interfaces.Persistence
+namespace StellarWallet.Domain.Interfaces.Persistence;
+
+public interface IRepository<T> where T : class
 {
-    public interface IRepository<T> where T : class
-    {
-        Task<IEnumerable<T>> GetAll(Expression<Func<T, bool>>? filter = null, Func<IQueryable<T>, IOrderedQueryable<T>>? orderBy = null, string? includeProperties = null, bool istracking = true);
-        Task<T?> GetById(int id);
-        Task Add(T entity);
-        void Delete(T entity);
-        void Update(T entity);
-    }
+    Task<IEnumerable<T>> GetAll(Expression<Func<T, bool>>? filter = null, Func<IQueryable<T>, IOrderedQueryable<T>>? orderBy = null, string? includeProperties = null, bool istracking = true);
+    Task<T?> GetById(int id);
+    Task Add(T entity);
+    void Delete(T entity);
+    void Update(T entity);
 }

--- a/StellarWallet.Domain/Interfaces/Persistence/IUnitOfWork.cs
+++ b/StellarWallet.Domain/Interfaces/Persistence/IUnitOfWork.cs
@@ -1,10 +1,9 @@
-﻿namespace StellarWallet.Domain.Interfaces.Persistence
+﻿namespace StellarWallet.Domain.Interfaces.Persistence;
+
+public interface IUnitOfWork : IDisposable
 {
-    public interface IUnitOfWork : IDisposable
-    {
-        IUserRepository User { get; }
-        IBlockchainAccountRepository BlockchainAccount { get; }
-        IUserContactRepository UserContact { get; }
-        Task Save();
-    }
+    IUserRepository User { get; }
+    IBlockchainAccountRepository BlockchainAccount { get; }
+    IUserContactRepository UserContact { get; }
+    Task Save();
 }

--- a/StellarWallet.Domain/Interfaces/Persistence/IUserContactRepository.cs
+++ b/StellarWallet.Domain/Interfaces/Persistence/IUserContactRepository.cs
@@ -1,9 +1,8 @@
 ﻿using StellarWallet.Domain.Entities;
 
-namespace StellarWallet.Domain.Interfaces.Persistence
+namespace StellarWallet.Domain.Interfaces.Persistence;
+
+public interface IUserContactRepository : IRepository<UserContact>
 {
-    public interface IUserContactRepository : IRepository<UserContact>
-    {
-        Task Delete(int id);
-    }
+    Task Delete(int id);
 }

--- a/StellarWallet.Domain/Interfaces/Persistence/IUserRepository.cs
+++ b/StellarWallet.Domain/Interfaces/Persistence/IUserRepository.cs
@@ -1,10 +1,9 @@
 ﻿using StellarWallet.Domain.Entities;
 
-namespace StellarWallet.Domain.Interfaces.Persistence
+namespace StellarWallet.Domain.Interfaces.Persistence;
+
+public interface IUserRepository : IRepository<User>
 {
-    public interface IUserRepository : IRepository<User>
-    {
-        Task<User?> GetBy(string criteria, string value);
-        Task Delete(int id);
-    }
+    Task<User?> GetBy(string criteria, string value);
+    Task Delete(int id);
 }

--- a/StellarWallet.Domain/Interfaces/Result/IResult.cs
+++ b/StellarWallet.Domain/Interfaces/Result/IResult.cs
@@ -1,6 +1,4 @@
-﻿using StellarWallet.Domain.Result;
-
-namespace StellarWallet.Domain.Interfaces.Result;
+﻿namespace StellarWallet.Domain.Interfaces.Result;
 
 public interface IResult<out TValue, out TError>
 {

--- a/StellarWallet.Domain/Interfaces/Result/IResult.cs
+++ b/StellarWallet.Domain/Interfaces/Result/IResult.cs
@@ -1,11 +1,10 @@
 ﻿using StellarWallet.Domain.Result;
 
-namespace StellarWallet.Domain.Interfaces.Result
+namespace StellarWallet.Domain.Interfaces.Result;
+
+public interface IResult<out TValue, out TError>
 {
-    public interface IResult<out TValue, out TError>
-    {
-        TValue Value { get; }
-        bool IsSuccess { get; }
-        TError Error { get; }
-    }
+    TValue Value { get; }
+    bool IsSuccess { get; }
+    TError Error { get; }
 }

--- a/StellarWallet.Domain/Interfaces/Services/IBlockchainService.cs
+++ b/StellarWallet.Domain/Interfaces/Services/IBlockchainService.cs
@@ -1,6 +1,5 @@
 ﻿using StellarWallet.Domain.Entities;
 using StellarWallet.Domain.Errors;
-using StellarWallet.Domain.Interfaces.Result;
 using StellarWallet.Domain.Result;
 using StellarWallet.Domain.Structs;
 

--- a/StellarWallet.Domain/Interfaces/Services/IBlockchainService.cs
+++ b/StellarWallet.Domain/Interfaces/Services/IBlockchainService.cs
@@ -4,15 +4,14 @@ using StellarWallet.Domain.Interfaces.Result;
 using StellarWallet.Domain.Result;
 using StellarWallet.Domain.Structs;
 
-namespace StellarWallet.Domain.Interfaces.Services
+namespace StellarWallet.Domain.Interfaces.Services;
+
+public interface IBlockchainService
 {
-    public interface IBlockchainService
-    {
-        public Result<BlockchainAccount, CustomError> CreateAccount(int userId);
-        public Result<AccountKeyPair, CustomError> CreateKeyPair();
-        public Task<Result<bool, CustomError>> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount, string assetIssuer, string assetCode, string memo);
-        public Task<Result<BlockchainPayment[], CustomError>> GetPayments(string publicKey);
-        public Task<Result<bool, CustomError>> GetTestFunds(string publicKey);
-        public Task<Result<List<AccountBalances>, CustomError>> GetBalances(string publicKey);
-    }
+    public Result<BlockchainAccount, CustomError> CreateAccount(int userId);
+    public Result<AccountKeyPair, CustomError> CreateKeyPair();
+    public Task<Result<bool, CustomError>> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount, string assetIssuer, string assetCode, string memo);
+    public Task<Result<BlockchainPayment[], CustomError>> GetPayments(string publicKey);
+    public Task<Result<bool, CustomError>> GetTestFunds(string publicKey);
+    public Task<Result<List<AccountBalances>, CustomError>> GetBalances(string publicKey);
 }

--- a/StellarWallet.Domain/Interfaces/Services/IEncryptionService.cs
+++ b/StellarWallet.Domain/Interfaces/Services/IEncryptionService.cs
@@ -1,8 +1,7 @@
-﻿namespace StellarWallet.Domain.Interfaces.Services
+﻿namespace StellarWallet.Domain.Interfaces.Services;
+
+public interface IEncryptionService
 {
-    public interface IEncryptionService
-    {
-        string Encrypt(string text);
-        bool Verify(string text, string hash);
-    }
+    string Encrypt(string text);
+    bool Verify(string text, string hash);
 }

--- a/StellarWallet.Domain/Interfaces/Services/IJwtService.cs
+++ b/StellarWallet.Domain/Interfaces/Services/IJwtService.cs
@@ -1,11 +1,10 @@
 ﻿using StellarWallet.Domain.Errors;
 using StellarWallet.Domain.Result;
 
-namespace StellarWallet.Domain.Interfaces.Services
+namespace StellarWallet.Domain.Interfaces.Services;
+
+public interface IJwtService
 {
-    public interface IJwtService
-    {
-        Result<string, CustomError> CreateToken(string email, string role);
-        Result<string, CustomError> DecodeToken(string token);
-    }
+    Result<string, CustomError> CreateToken(string email, string role);
+    Result<string, CustomError> DecodeToken(string token);
 }

--- a/StellarWallet.Domain/Result/Result.cs
+++ b/StellarWallet.Domain/Result/Result.cs
@@ -1,42 +1,48 @@
-﻿using StellarWallet.Domain.Interfaces.Result;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
+using StellarWallet.Domain.Interfaces.Result;
 
-namespace StellarWallet.Domain.Result
+namespace StellarWallet.Domain.Result;
+
+public class Result<TValue, TError> : IResult<TValue, TError>
 {
-    public class Result<TValue, TError> : IResult<TValue, TError>
+    public bool IsSuccess { get; private set; }
+    public TValue Value { get; private set; }
+    public TError Error { get; private set; }
+
+    [JsonConstructor]
+    public Result(bool isSuccess, TValue? value, TError? error)
     {
-        public bool IsSuccess { get; private set; }
-        public TValue Value { get; private set; }
-        public TError Error { get; private set; }
+        IsSuccess = isSuccess;
+        Value = value ?? default!;
+        Error = error ?? default!;
+    }
 
-        [JsonConstructor]
-        public Result(bool isSuccess, TValue? value, TError? error)
-        {
-            IsSuccess = isSuccess;
-            Value = value ?? default!;
-            Error = error ?? default!;
-        }
+    public Result() { }
 
-        public Result() { }
+    private Result(TValue value)
+    {
+        IsSuccess = true;
+        Value = value;
+        Error = default!;
+    }
 
-        private Result(TValue value)
-        {
-            IsSuccess = true;
-            Value = value;
-            Error = default!;
-        }
+    private Result(TError error)
+    {
+        IsSuccess = false;
+        Error = error;
+        Value = default!;
+    }
 
-        private Result(TError error)
-        {
-            IsSuccess = false;
-            Error = error;
-            Value = default!;
-        }
+    public static Result<TValue, TError> Success(TValue value) => new(value);
+    public static Result<TValue, TError> Failure(TError error) => new(error);
 
-        public static Result<TValue, TError> Success(TValue value) => new(value);
-        public static Result<TValue, TError> Failure(TError error) => new(error);
+    public static implicit operator Result<TValue, TError>(TValue success)
+    {
+        return Success(success);
+    }
 
-        public static implicit operator Result<TValue, TError>(TValue success) => Success(success);
-        public static implicit operator Result<TValue, TError>(TError error) => Failure(error);
+    public static implicit operator Result<TValue, TError>(TError error)
+    {
+        return Failure(error);
     }
 }

--- a/StellarWallet.Domain/StellarWallet.Domain.csproj
+++ b/StellarWallet.Domain/StellarWallet.Domain.csproj
@@ -6,4 +6,15 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.3.0.106239">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\.editorconfig" />
+  </ItemGroup>
+
 </Project>

--- a/StellarWallet.Domain/Structs/AccountBalances.cs
+++ b/StellarWallet.Domain/Structs/AccountBalances.cs
@@ -1,9 +1,8 @@
-﻿namespace StellarWallet.Domain.Structs
+﻿namespace StellarWallet.Domain.Structs;
+
+public struct AccountBalances
 {
-    public struct AccountBalances
-    {
-        public string Asset { get; set; }
-        public string Amount { get; set; }
-        public string Issuer { get; set; }
-    }
+    public string Asset { get; set; }
+    public string Amount { get; set; }
+    public string Issuer { get; set; }
 }

--- a/StellarWallet.Domain/Structs/AccountKeyPair.cs
+++ b/StellarWallet.Domain/Structs/AccountKeyPair.cs
@@ -1,8 +1,7 @@
-﻿namespace StellarWallet.Domain.Structs
+﻿namespace StellarWallet.Domain.Structs;
+
+public struct AccountKeyPair
 {
-    public struct AccountKeyPair
-    {
-        public string PublicKey { get; set; }
-        public string SecretKey { get; set; }
-    }
+    public string PublicKey { get; set; }
+    public string SecretKey { get; set; }
 }

--- a/StellarWallet.Domain/Structs/BlockchainPayment.cs
+++ b/StellarWallet.Domain/Structs/BlockchainPayment.cs
@@ -1,14 +1,13 @@
-﻿namespace StellarWallet.Domain.Structs
+﻿namespace StellarWallet.Domain.Structs;
+
+public struct BlockchainPayment
 {
-    public struct BlockchainPayment
-    {
-        public string Id { get; set; }
-        public string From { get; set; }
-        public string To { get; set; }
-        public string Amount { get; set; }
-        public string Asset { get; set; }
-        public string CreatedAt { get; set; }
-        public bool WasSuccessful { get; set; }
-    }
+    public string Id { get; set; }
+    public string From { get; set; }
+    public string To { get; set; }
+    public string Amount { get; set; }
+    public string Asset { get; set; }
+    public string CreatedAt { get; set; }
+    public bool WasSuccessful { get; set; }
 }
 

--- a/StellarWallet.Infrastructure/Config/BlockchainAccountConfiguration.cs
+++ b/StellarWallet.Infrastructure/Config/BlockchainAccountConfiguration.cs
@@ -2,22 +2,21 @@
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using StellarWallet.Domain.Entities;
 
-namespace StellarWallet.Infrastructure.Config
+namespace StellarWallet.Infrastructure.Config;
+
+public class BlockchainAccountConfiguration : IEntityTypeConfiguration<BlockchainAccount>
 {
-    public class BlockchainAccountConfiguration : IEntityTypeConfiguration<BlockchainAccount>
+    public void Configure(EntityTypeBuilder<BlockchainAccount> builder)
     {
-        public void Configure(EntityTypeBuilder<BlockchainAccount> builder)
-        {
-            builder.HasKey(b => b.Id);
-            builder.HasIndex(b => b.PublicKey).IsUnique();
+        builder.HasKey(b => b.Id);
+        builder.HasIndex(b => b.PublicKey).IsUnique();
 
-            builder.Property(b => b.PublicKey).IsRequired().HasMaxLength(56);
-            builder.Property(b => b.SecretKey).IsRequired().HasMaxLength(56);
-            builder.Property(b => b.UserId).IsRequired();
+        builder.Property(b => b.PublicKey).IsRequired().HasMaxLength(56);
+        builder.Property(b => b.SecretKey).IsRequired().HasMaxLength(56);
+        builder.Property(b => b.UserId).IsRequired();
 
-            builder.HasOne(b => b.User)
-                .WithMany(u => u.BlockchainAccounts)
-                .HasForeignKey(b => b.UserId);
-        }
+        builder.HasOne(b => b.User)
+            .WithMany(u => u.BlockchainAccounts)
+            .HasForeignKey(b => b.UserId);
     }
 }

--- a/StellarWallet.Infrastructure/Config/UserConfiguration.cs
+++ b/StellarWallet.Infrastructure/Config/UserConfiguration.cs
@@ -2,24 +2,23 @@
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using StellarWallet.Domain.Entities;
 
-namespace StellarWallet.Infrastructure.Config
+namespace StellarWallet.Infrastructure.Config;
+
+public class UserConfiguration : IEntityTypeConfiguration<User>
 {
-    public class UserConfiguration : IEntityTypeConfiguration<User>
+    public void Configure(EntityTypeBuilder<User> builder)
     {
-        public void Configure(EntityTypeBuilder<User> builder)
-        {
-            builder.HasKey(u => u.Id);
-            builder.HasIndex(u => u.Email).IsUnique();
+        builder.HasKey(u => u.Id);
+        builder.HasIndex(u => u.Email).IsUnique();
 
-            builder.Property(u => u.Name).IsRequired().HasMaxLength(50);
-            builder.Property(u => u.LastName).IsRequired().HasMaxLength(50);
-            builder.Property(u => u.Password).IsRequired().IsUnicode();
-            builder.Property(u => u.PublicKey).IsRequired().HasMaxLength(56);
-            builder.Property(u => u.SecretKey).IsRequired().HasMaxLength(56);
-            builder.Property(u => u.Role).HasDefaultValue("guest");
+        builder.Property(u => u.Name).IsRequired().HasMaxLength(50);
+        builder.Property(u => u.LastName).IsRequired().HasMaxLength(50);
+        builder.Property(u => u.Password).IsRequired().IsUnicode();
+        builder.Property(u => u.PublicKey).IsRequired().HasMaxLength(56);
+        builder.Property(u => u.SecretKey).IsRequired().HasMaxLength(56);
+        builder.Property(u => u.Role).HasDefaultValue("guest");
 
-            builder.HasMany(u => u.BlockchainAccounts).WithOne(b => b.User).HasForeignKey(b => b.UserId);
-            builder.HasMany(u => u.UserContacts).WithOne(uc => uc.User).HasForeignKey(uc => uc.UserId).OnDelete(DeleteBehavior.NoAction);
-        }
+        builder.HasMany(u => u.BlockchainAccounts).WithOne(b => b.User).HasForeignKey(b => b.UserId);
+        builder.HasMany(u => u.UserContacts).WithOne(uc => uc.User).HasForeignKey(uc => uc.UserId).OnDelete(DeleteBehavior.NoAction);
     }
 }

--- a/StellarWallet.Infrastructure/Config/UserContactConfiguration.cs
+++ b/StellarWallet.Infrastructure/Config/UserContactConfiguration.cs
@@ -2,27 +2,26 @@
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using StellarWallet.Domain.Entities;
 
-namespace StellarWallet.Infrastructure.Config
+namespace StellarWallet.Infrastructure.Config;
+
+public class UserContactConfiguration : IEntityTypeConfiguration<UserContact>
 {
-    public class UserContactConfiguration : IEntityTypeConfiguration<UserContact>
+    public void Configure(EntityTypeBuilder<UserContact> builder)
     {
-        public void Configure(EntityTypeBuilder<UserContact> builder)
-        {
-            builder.HasKey(uc => uc.Id);
+        builder.HasKey(uc => uc.Id);
 
-            builder.Property(uc => uc.Alias)
-                .IsRequired()
-                .HasMaxLength(50);
-            builder.Property(uc => uc.PublicKey)
-                .IsRequired()
-                .HasMaxLength(56);
-            builder.Property(uc => uc.UserId)
-                .IsRequired();
+        builder.Property(uc => uc.Alias)
+            .IsRequired()
+            .HasMaxLength(50);
+        builder.Property(uc => uc.PublicKey)
+            .IsRequired()
+            .HasMaxLength(56);
+        builder.Property(uc => uc.UserId)
+            .IsRequired();
 
-            builder.HasOne(uc => uc.User)
-                .WithMany(u => u.UserContacts)
-                .HasForeignKey(uc => uc.UserId)
-                .OnDelete(DeleteBehavior.NoAction);
-        }
+        builder.HasOne(uc => uc.User)
+            .WithMany(u => u.UserContacts)
+            .HasForeignKey(uc => uc.UserId)
+            .OnDelete(DeleteBehavior.NoAction);
     }
 }

--- a/StellarWallet.Infrastructure/DatabaseContext.cs
+++ b/StellarWallet.Infrastructure/DatabaseContext.cs
@@ -1,24 +1,23 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Reflection;
+using Microsoft.EntityFrameworkCore;
 using StellarWallet.Domain.Entities;
-using System.Reflection;
 
-namespace StellarWallet.Infrastructure
+namespace StellarWallet.Infrastructure;
+
+public class DatabaseContext : DbContext
 {
-    public class DatabaseContext : DbContext
+    public DbSet<User> Users { get; set; }
+    public DbSet<BlockchainAccount> BlockchainAccounts { get; set; }
+    public DbSet<UserContact> UserContacts { get; set; }
+
+    public DatabaseContext(DbContextOptions<DatabaseContext> options)
+    : base(options)
     {
-        public DbSet<User> Users { get; set; }
-        public DbSet<BlockchainAccount> BlockchainAccounts { get; set; }
-        public DbSet<UserContact> UserContacts { get; set; }
+    }
 
-        public DatabaseContext(DbContextOptions<DatabaseContext> options)
-        : base(options)
-        {
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            base.OnModelCreating(modelBuilder);
-            modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
-        }
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
     }
 }

--- a/StellarWallet.Infrastructure/Migrations/20240511011131_InitialMigration.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240511011131_InitialMigration.cs
@@ -2,120 +2,119 @@
 
 #nullable disable
 
-namespace StellarWallet.Infrastructure.Migrations
+namespace StellarWallet.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class InitialMigration : Migration
 {
     /// <inheritdoc />
-    public partial class InitialMigration : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.CreateTable(
-                name: "Users",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    Name = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
-                    LastName = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
-                    Email = table.Column<string>(type: "nvarchar(450)", nullable: false),
-                    Password = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                    PublicKey = table.Column<string>(type: "nvarchar(56)", maxLength: 56, nullable: false),
-                    SecretKey = table.Column<string>(type: "nvarchar(56)", maxLength: 56, nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_Users", x => x.Id);
-                });
+        migrationBuilder.CreateTable(
+            name: "Users",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "int", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                Name = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                LastName = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                Email = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                Password = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                PublicKey = table.Column<string>(type: "nvarchar(56)", maxLength: 56, nullable: false),
+                SecretKey = table.Column<string>(type: "nvarchar(56)", maxLength: 56, nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Users", x => x.Id);
+            });
 
-            migrationBuilder.CreateTable(
-                name: "BlockchainAccounts",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    PublicKey = table.Column<string>(type: "nvarchar(56)", maxLength: 56, nullable: false),
-                    SecretKey = table.Column<string>(type: "nvarchar(56)", maxLength: 56, nullable: false),
-                    UserId = table.Column<int>(type: "int", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_BlockchainAccounts", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_BlockchainAccounts_Users_UserId",
-                        column: x => x.UserId,
-                        principalTable: "Users",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
+        migrationBuilder.CreateTable(
+            name: "BlockchainAccounts",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "int", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                PublicKey = table.Column<string>(type: "nvarchar(56)", maxLength: 56, nullable: false),
+                SecretKey = table.Column<string>(type: "nvarchar(56)", maxLength: 56, nullable: false),
+                UserId = table.Column<int>(type: "int", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_BlockchainAccounts", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_BlockchainAccounts_Users_UserId",
+                    column: x => x.UserId,
+                    principalTable: "Users",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
 
-            migrationBuilder.CreateTable(
-                name: "UserContacts",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    Alias = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
-                    UserId = table.Column<int>(type: "int", nullable: false),
-                    BlockchainAccountId = table.Column<int>(type: "int", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_UserContacts", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_UserContacts_BlockchainAccounts_BlockchainAccountId",
-                        column: x => x.BlockchainAccountId,
-                        principalTable: "BlockchainAccounts",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                    table.ForeignKey(
-                        name: "FK_UserContacts_Users_UserId",
-                        column: x => x.UserId,
-                        principalTable: "Users",
-                        principalColumn: "Id");
-                });
+        migrationBuilder.CreateTable(
+            name: "UserContacts",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "int", nullable: false)
+                    .Annotation("SqlServer:Identity", "1, 1"),
+                Alias = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                UserId = table.Column<int>(type: "int", nullable: false),
+                BlockchainAccountId = table.Column<int>(type: "int", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_UserContacts", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_UserContacts_BlockchainAccounts_BlockchainAccountId",
+                    column: x => x.BlockchainAccountId,
+                    principalTable: "BlockchainAccounts",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_UserContacts_Users_UserId",
+                    column: x => x.UserId,
+                    principalTable: "Users",
+                    principalColumn: "Id");
+            });
 
-            migrationBuilder.CreateIndex(
-                name: "IX_BlockchainAccounts_PublicKey",
-                table: "BlockchainAccounts",
-                column: "PublicKey",
-                unique: true);
+        migrationBuilder.CreateIndex(
+            name: "IX_BlockchainAccounts_PublicKey",
+            table: "BlockchainAccounts",
+            column: "PublicKey",
+            unique: true);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_BlockchainAccounts_UserId",
-                table: "BlockchainAccounts",
-                column: "UserId");
+        migrationBuilder.CreateIndex(
+            name: "IX_BlockchainAccounts_UserId",
+            table: "BlockchainAccounts",
+            column: "UserId");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_UserContacts_BlockchainAccountId",
-                table: "UserContacts",
-                column: "BlockchainAccountId",
-                unique: true);
+        migrationBuilder.CreateIndex(
+            name: "IX_UserContacts_BlockchainAccountId",
+            table: "UserContacts",
+            column: "BlockchainAccountId",
+            unique: true);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_UserContacts_UserId_BlockchainAccountId",
-                table: "UserContacts",
-                columns: new[] { "UserId", "BlockchainAccountId" },
-                unique: true);
+        migrationBuilder.CreateIndex(
+            name: "IX_UserContacts_UserId_BlockchainAccountId",
+            table: "UserContacts",
+            columns: new[] { "UserId", "BlockchainAccountId" },
+            unique: true);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_Users_Email",
-                table: "Users",
-                column: "Email",
-                unique: true);
-        }
+        migrationBuilder.CreateIndex(
+            name: "IX_Users_Email",
+            table: "Users",
+            column: "Email",
+            unique: true);
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropTable(
-                name: "UserContacts");
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "UserContacts");
 
-            migrationBuilder.DropTable(
-                name: "BlockchainAccounts");
+        migrationBuilder.DropTable(
+            name: "BlockchainAccounts");
 
-            migrationBuilder.DropTable(
-                name: "Users");
-        }
+        migrationBuilder.DropTable(
+            name: "Users");
     }
 }

--- a/StellarWallet.Infrastructure/Migrations/20240511040127_UserContactsUpdate.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240511040127_UserContactsUpdate.cs
@@ -2,100 +2,99 @@
 
 #nullable disable
 
-namespace StellarWallet.Infrastructure.Migrations
+namespace StellarWallet.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class UserContactsUpdate : Migration
 {
     /// <inheritdoc />
-    public partial class UserContactsUpdate : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropForeignKey(
-                name: "FK_UserContacts_BlockchainAccounts_BlockchainAccountId",
-                table: "UserContacts");
+        migrationBuilder.DropForeignKey(
+            name: "FK_UserContacts_BlockchainAccounts_BlockchainAccountId",
+            table: "UserContacts");
 
-            migrationBuilder.DropIndex(
-                name: "IX_UserContacts_BlockchainAccountId",
-                table: "UserContacts");
+        migrationBuilder.DropIndex(
+            name: "IX_UserContacts_BlockchainAccountId",
+            table: "UserContacts");
 
-            migrationBuilder.DropIndex(
-                name: "IX_UserContacts_UserId_BlockchainAccountId",
-                table: "UserContacts");
+        migrationBuilder.DropIndex(
+            name: "IX_UserContacts_UserId_BlockchainAccountId",
+            table: "UserContacts");
 
-            migrationBuilder.DropColumn(
-                name: "BlockchainAccountId",
-                table: "UserContacts");
+        migrationBuilder.DropColumn(
+            name: "BlockchainAccountId",
+            table: "UserContacts");
 
-            migrationBuilder.AddColumn<int>(
-                name: "UserContactId",
-                table: "BlockchainAccounts",
-                type: "int",
-                nullable: true);
+        migrationBuilder.AddColumn<int>(
+            name: "UserContactId",
+            table: "BlockchainAccounts",
+            type: "int",
+            nullable: true);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_UserContacts_UserId",
-                table: "UserContacts",
-                column: "UserId",
-                unique: true);
+        migrationBuilder.CreateIndex(
+            name: "IX_UserContacts_UserId",
+            table: "UserContacts",
+            column: "UserId",
+            unique: true);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_BlockchainAccounts_UserContactId",
-                table: "BlockchainAccounts",
-                column: "UserContactId");
+        migrationBuilder.CreateIndex(
+            name: "IX_BlockchainAccounts_UserContactId",
+            table: "BlockchainAccounts",
+            column: "UserContactId");
 
-            migrationBuilder.AddForeignKey(
-                name: "FK_BlockchainAccounts_UserContacts_UserContactId",
-                table: "BlockchainAccounts",
-                column: "UserContactId",
-                principalTable: "UserContacts",
-                principalColumn: "Id");
-        }
+        migrationBuilder.AddForeignKey(
+            name: "FK_BlockchainAccounts_UserContacts_UserContactId",
+            table: "BlockchainAccounts",
+            column: "UserContactId",
+            principalTable: "UserContacts",
+            principalColumn: "Id");
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropForeignKey(
-                name: "FK_BlockchainAccounts_UserContacts_UserContactId",
-                table: "BlockchainAccounts");
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropForeignKey(
+            name: "FK_BlockchainAccounts_UserContacts_UserContactId",
+            table: "BlockchainAccounts");
 
-            migrationBuilder.DropIndex(
-                name: "IX_UserContacts_UserId",
-                table: "UserContacts");
+        migrationBuilder.DropIndex(
+            name: "IX_UserContacts_UserId",
+            table: "UserContacts");
 
-            migrationBuilder.DropIndex(
-                name: "IX_BlockchainAccounts_UserContactId",
-                table: "BlockchainAccounts");
+        migrationBuilder.DropIndex(
+            name: "IX_BlockchainAccounts_UserContactId",
+            table: "BlockchainAccounts");
 
-            migrationBuilder.DropColumn(
-                name: "UserContactId",
-                table: "BlockchainAccounts");
+        migrationBuilder.DropColumn(
+            name: "UserContactId",
+            table: "BlockchainAccounts");
 
-            migrationBuilder.AddColumn<int>(
-                name: "BlockchainAccountId",
-                table: "UserContacts",
-                type: "int",
-                nullable: false,
-                defaultValue: 0);
+        migrationBuilder.AddColumn<int>(
+            name: "BlockchainAccountId",
+            table: "UserContacts",
+            type: "int",
+            nullable: false,
+            defaultValue: 0);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_UserContacts_BlockchainAccountId",
-                table: "UserContacts",
-                column: "BlockchainAccountId",
-                unique: true);
+        migrationBuilder.CreateIndex(
+            name: "IX_UserContacts_BlockchainAccountId",
+            table: "UserContacts",
+            column: "BlockchainAccountId",
+            unique: true);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_UserContacts_UserId_BlockchainAccountId",
-                table: "UserContacts",
-                columns: new[] { "UserId", "BlockchainAccountId" },
-                unique: true);
+        migrationBuilder.CreateIndex(
+            name: "IX_UserContacts_UserId_BlockchainAccountId",
+            table: "UserContacts",
+            columns: new[] { "UserId", "BlockchainAccountId" },
+            unique: true);
 
-            migrationBuilder.AddForeignKey(
-                name: "FK_UserContacts_BlockchainAccounts_BlockchainAccountId",
-                table: "UserContacts",
-                column: "BlockchainAccountId",
-                principalTable: "BlockchainAccounts",
-                principalColumn: "Id",
-                onDelete: ReferentialAction.Cascade);
-        }
+        migrationBuilder.AddForeignKey(
+            name: "FK_UserContacts_BlockchainAccounts_BlockchainAccountId",
+            table: "UserContacts",
+            column: "BlockchainAccountId",
+            principalTable: "BlockchainAccounts",
+            principalColumn: "Id",
+            onDelete: ReferentialAction.Cascade);
     }
 }

--- a/StellarWallet.Infrastructure/Migrations/20240511204834_UserContactNewPK.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240511204834_UserContactNewPK.cs
@@ -2,46 +2,45 @@
 
 #nullable disable
 
-namespace StellarWallet.Infrastructure.Migrations
+namespace StellarWallet.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class UserContactNewPK : Migration
 {
     /// <inheritdoc />
-    public partial class UserContactNewPK : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropIndex(
-                name: "IX_UserContacts_UserId",
-                table: "UserContacts");
+        migrationBuilder.DropIndex(
+            name: "IX_UserContacts_UserId",
+            table: "UserContacts");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_UserContacts_Id",
-                table: "UserContacts",
-                column: "Id",
-                unique: true);
+        migrationBuilder.CreateIndex(
+            name: "IX_UserContacts_Id",
+            table: "UserContacts",
+            column: "Id",
+            unique: true);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_UserContacts_UserId",
-                table: "UserContacts",
-                column: "UserId");
-        }
+        migrationBuilder.CreateIndex(
+            name: "IX_UserContacts_UserId",
+            table: "UserContacts",
+            column: "UserId");
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropIndex(
-                name: "IX_UserContacts_Id",
-                table: "UserContacts");
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_UserContacts_Id",
+            table: "UserContacts");
 
-            migrationBuilder.DropIndex(
-                name: "IX_UserContacts_UserId",
-                table: "UserContacts");
+        migrationBuilder.DropIndex(
+            name: "IX_UserContacts_UserId",
+            table: "UserContacts");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_UserContacts_UserId",
-                table: "UserContacts",
-                column: "UserId",
-                unique: true);
-        }
+        migrationBuilder.CreateIndex(
+            name: "IX_UserContacts_UserId",
+            table: "UserContacts",
+            column: "UserId",
+            unique: true);
     }
 }

--- a/StellarWallet.Infrastructure/Migrations/20240512143050_AddPublicKeyToUserContact.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240512143050_AddPublicKeyToUserContact.cs
@@ -2,28 +2,27 @@
 
 #nullable disable
 
-namespace StellarWallet.Infrastructure.Migrations
+namespace StellarWallet.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddPublicKeyToUserContact : Migration
 {
     /// <inheritdoc />
-    public partial class AddPublicKeyToUserContact : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AddColumn<string>(
-                name: "PublicKey",
-                table: "UserContacts",
-                type: "nvarchar(max)",
-                nullable: false,
-                defaultValue: "");
-        }
+        migrationBuilder.AddColumn<string>(
+            name: "PublicKey",
+            table: "UserContacts",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "");
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropColumn(
-                name: "PublicKey",
-                table: "UserContacts");
-        }
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "PublicKey",
+            table: "UserContacts");
     }
 }

--- a/StellarWallet.Infrastructure/Migrations/20240512143354_UpdatePublicKeyInUserContact.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240512143354_UpdatePublicKeyInUserContact.cs
@@ -2,21 +2,20 @@
 
 #nullable disable
 
-namespace StellarWallet.Infrastructure.Migrations
+namespace StellarWallet.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class UpdatePublicKeyInUserContact : Migration
 {
     /// <inheritdoc />
-    public partial class UpdatePublicKeyInUserContact : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
 
-        }
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-
-        }
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        // Method intentionally left empty.
     }
 }

--- a/StellarWallet.Infrastructure/Migrations/20240512230338_AddRoleInUser.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240512230338_AddRoleInUser.cs
@@ -2,28 +2,27 @@
 
 #nullable disable
 
-namespace StellarWallet.Infrastructure.Migrations
+namespace StellarWallet.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddRoleInUser : Migration
 {
     /// <inheritdoc />
-    public partial class AddRoleInUser : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AddColumn<string>(
-                name: "Role",
-                table: "Users",
-                type: "nvarchar(max)",
-                nullable: false,
-                defaultValue: "");
-        }
+        migrationBuilder.AddColumn<string>(
+            name: "Role",
+            table: "Users",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "");
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropColumn(
-                name: "Role",
-                table: "Users");
-        }
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "Role",
+            table: "Users");
     }
 }

--- a/StellarWallet.Infrastructure/Migrations/20240801233509_UpdateEntitiesRelations.cs
+++ b/StellarWallet.Infrastructure/Migrations/20240801233509_UpdateEntitiesRelations.cs
@@ -2,63 +2,62 @@
 
 #nullable disable
 
-namespace StellarWallet.Infrastructure.Migrations
+namespace StellarWallet.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class UpdateEntitiesRelations : Migration
 {
     /// <inheritdoc />
-    public partial class UpdateEntitiesRelations : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropIndex(
-                name: "IX_UserContacts_Id",
-                table: "UserContacts");
+        migrationBuilder.DropIndex(
+            name: "IX_UserContacts_Id",
+            table: "UserContacts");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "Role",
-                table: "Users",
-                type: "nvarchar(max)",
-                nullable: false,
-                defaultValue: "guest",
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)");
+        migrationBuilder.AlterColumn<string>(
+            name: "Role",
+            table: "Users",
+            type: "nvarchar(max)",
+            nullable: false,
+            defaultValue: "guest",
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "PublicKey",
-                table: "UserContacts",
-                type: "nvarchar(56)",
-                maxLength: 56,
-                nullable: false,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)");
-        }
+        migrationBuilder.AlterColumn<string>(
+            name: "PublicKey",
+            table: "UserContacts",
+            type: "nvarchar(56)",
+            maxLength: 56,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)");
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.AlterColumn<string>(
-                name: "Role",
-                table: "Users",
-                type: "nvarchar(max)",
-                nullable: false,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(max)",
-                oldDefaultValue: "guest");
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "Role",
+            table: "Users",
+            type: "nvarchar(max)",
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(max)",
+            oldDefaultValue: "guest");
 
-            migrationBuilder.AlterColumn<string>(
-                name: "PublicKey",
-                table: "UserContacts",
-                type: "nvarchar(max)",
-                nullable: false,
-                oldClrType: typeof(string),
-                oldType: "nvarchar(56)",
-                oldMaxLength: 56);
+        migrationBuilder.AlterColumn<string>(
+            name: "PublicKey",
+            table: "UserContacts",
+            type: "nvarchar(max)",
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "nvarchar(56)",
+            oldMaxLength: 56);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_UserContacts_Id",
-                table: "UserContacts",
-                column: "Id",
-                unique: true);
-        }
+        migrationBuilder.CreateIndex(
+            name: "IX_UserContacts_Id",
+            table: "UserContacts",
+            column: "Id",
+            unique: true);
     }
 }

--- a/StellarWallet.Infrastructure/Repositories/BlockchainAccountRepository.cs
+++ b/StellarWallet.Infrastructure/Repositories/BlockchainAccountRepository.cs
@@ -1,15 +1,14 @@
 ﻿using StellarWallet.Domain.Entities;
 using StellarWallet.Domain.Interfaces.Persistence;
 
-namespace StellarWallet.Infrastructure.Repositories
-{
-    public class BlockchainAccountRepository : Repository<BlockchainAccount>, IBlockchainAccountRepository
-    {
-        private readonly DatabaseContext _context;
+namespace StellarWallet.Infrastructure.Repositories;
 
-        public BlockchainAccountRepository(DatabaseContext context) : base(context)
-        {
-            _context = context;
-        }
+public class BlockchainAccountRepository : Repository<BlockchainAccount>, IBlockchainAccountRepository
+{
+    private readonly DatabaseContext _context;
+
+    public BlockchainAccountRepository(DatabaseContext context) : base(context)
+    {
+        _context = context;
     }
 }

--- a/StellarWallet.Infrastructure/Repositories/UnitOfWork.cs
+++ b/StellarWallet.Infrastructure/Repositories/UnitOfWork.cs
@@ -1,27 +1,26 @@
 ﻿using StellarWallet.Domain.Interfaces.Persistence;
 
-namespace StellarWallet.Infrastructure.Repositories
+namespace StellarWallet.Infrastructure.Repositories;
+
+public class UnitOfWork : IUnitOfWork
 {
-    public class UnitOfWork : IUnitOfWork
+    private readonly DatabaseContext _context;
+    public IUserRepository User { get; }
+    public IBlockchainAccountRepository BlockchainAccount { get; }
+    public IUserContactRepository UserContact { get; }
+
+    public UnitOfWork(DatabaseContext context)
     {
-        private readonly DatabaseContext _context;
-        public IUserRepository User { get; }
-        public IBlockchainAccountRepository BlockchainAccount { get; }
-        public IUserContactRepository UserContact { get; }
+        _context = context;
+        User = new UserRepository(_context);
+        BlockchainAccount = new BlockchainAccountRepository(_context);
+        UserContact = new UserContactRepository(_context);
+    }
 
-        public UnitOfWork(DatabaseContext context)
-        {
-            _context = context;
-            User = new UserRepository(_context);
-            BlockchainAccount = new BlockchainAccountRepository(_context);
-            UserContact = new UserContactRepository(_context);
-        }
+    public void Dispose() => _context.Dispose();
 
-        public void Dispose() => _context.Dispose();
-
-        public async Task Save()
-        {
-            await _context.SaveChangesAsync();
-        }
+    public async Task Save()
+    {
+        await _context.SaveChangesAsync();
     }
 }

--- a/StellarWallet.Infrastructure/Repositories/UserContactRepository.cs
+++ b/StellarWallet.Infrastructure/Repositories/UserContactRepository.cs
@@ -1,22 +1,21 @@
 ﻿using StellarWallet.Domain.Entities;
 using StellarWallet.Domain.Interfaces.Persistence;
 
-namespace StellarWallet.Infrastructure.Repositories
+namespace StellarWallet.Infrastructure.Repositories;
+
+public class UserContactRepository : Repository<UserContact>, IUserContactRepository
 {
-    public class UserContactRepository : Repository<UserContact>, IUserContactRepository
+    private readonly DatabaseContext _context;
+
+    public UserContactRepository(DatabaseContext context) : base(context)
     {
-        private readonly DatabaseContext _context;
+        _context = context;
+    }
 
-        public UserContactRepository(DatabaseContext context) : base(context)
-        {
-            _context = context;
-        }
-
-        public async Task Delete(int id)
-        {
-            UserContact? foundUserContact = await GetById(id) ?? throw new Exception("User contact not found");
-            _context.UserContacts.Remove(foundUserContact);
-            await _context.SaveChangesAsync();
-        }
+    public async Task Delete(int id)
+    {
+        var foundUserContact = await GetById(id) ?? throw new Exception("User contact not found");
+        _context.UserContacts.Remove(foundUserContact);
+        await _context.SaveChangesAsync();
     }
 }

--- a/StellarWallet.Infrastructure/Repositories/UserContactRepository.cs
+++ b/StellarWallet.Infrastructure/Repositories/UserContactRepository.cs
@@ -14,7 +14,7 @@ public class UserContactRepository : Repository<UserContact>, IUserContactReposi
 
     public async Task Delete(int id)
     {
-        var foundUserContact = await GetById(id) ?? throw new Exception("User contact not found");
+        var foundUserContact = await GetById(id) ?? throw new KeyNotFoundException("User contact not found");
         _context.UserContacts.Remove(foundUserContact);
         await _context.SaveChangesAsync();
     }

--- a/StellarWallet.Infrastructure/Repositories/UserRepository.cs
+++ b/StellarWallet.Infrastructure/Repositories/UserRepository.cs
@@ -13,10 +13,10 @@ public class UserRepository : Repository<User>, IUserRepository
         _context = context;
     }
 
-    public async Task<User?> GetBy(string paramName, string paramValue)
+    public async Task<User?> GetBy(string criteria, string value)
     {
-        var propertyInfo = typeof(User).GetProperty(paramName) ?? throw new ArgumentException($"Invalid property: '{paramName}'.");
-        var query = _context.Users.Where(u => EF.Property<string>(u, propertyInfo.Name) == paramValue).Include(u => u.BlockchainAccounts).Include(u => u.UserContacts);
+        var propertyInfo = typeof(User).GetProperty(criteria) ?? throw new ArgumentException($"Invalid property: '{criteria}'.");
+        var query = _context.Users.Where(u => EF.Property<string>(u, propertyInfo.Name) == value).Include(u => u.BlockchainAccounts).Include(u => u.UserContacts);
 
         try
         {
@@ -30,7 +30,7 @@ public class UserRepository : Repository<User>, IUserRepository
 
     public async Task Delete(int id)
     {
-        var foundUser = await GetById(id) ?? throw new Exception("User not found");
+        var foundUser = await GetById(id) ?? throw new KeyNotFoundException("User not found");
         _context.Users.Remove(foundUser);
         await _context.SaveChangesAsync();
     }

--- a/StellarWallet.Infrastructure/Repositories/UserRepository.cs
+++ b/StellarWallet.Infrastructure/Repositories/UserRepository.cs
@@ -2,37 +2,36 @@
 using StellarWallet.Domain.Entities;
 using StellarWallet.Domain.Interfaces.Persistence;
 
-namespace StellarWallet.Infrastructure.Repositories
+namespace StellarWallet.Infrastructure.Repositories;
+
+public class UserRepository : Repository<User>, IUserRepository
 {
-    public class UserRepository : Repository<User>, IUserRepository
+    private readonly DatabaseContext _context;
+
+    public UserRepository(DatabaseContext context) : base(context)
     {
-        private readonly DatabaseContext _context;
+        _context = context;
+    }
 
-        public UserRepository(DatabaseContext context) : base(context)
+    public async Task<User?> GetBy(string paramName, string paramValue)
+    {
+        var propertyInfo = typeof(User).GetProperty(paramName) ?? throw new ArgumentException($"Invalid property: '{paramName}'.");
+        var query = _context.Users.Where(u => EF.Property<string>(u, propertyInfo.Name) == paramValue).Include(u => u.BlockchainAccounts).Include(u => u.UserContacts);
+
+        try
         {
-            _context = context;
+            return await query.FirstAsync();
         }
-
-        public async Task<User?> GetBy(string paramName, string paramValue)
+        catch
         {
-            var propertyInfo = typeof(User).GetProperty(paramName) ?? throw new ArgumentException($"Invalid property: '{paramName}'.");
-            var query = _context.Users.Where(u => EF.Property<string>(u, propertyInfo.Name) == paramValue).Include(u => u.BlockchainAccounts).Include(u => u.UserContacts);
-
-            try
-            {
-                return await query.FirstAsync();
-            }
-            catch
-            {
-                return null;
-            }
+            return null;
         }
+    }
 
-        public async Task Delete(int id)
-        {
-            User? foundUser = await GetById(id) ?? throw new Exception("User not found");
-            _context.Users.Remove(foundUser);
-            await _context.SaveChangesAsync();
-        }
+    public async Task Delete(int id)
+    {
+        var foundUser = await GetById(id) ?? throw new Exception("User not found");
+        _context.Users.Remove(foundUser);
+        await _context.SaveChangesAsync();
     }
 }

--- a/StellarWallet.Infrastructure/Services/EncryptionService.cs
+++ b/StellarWallet.Infrastructure/Services/EncryptionService.cs
@@ -1,17 +1,16 @@
 ﻿using StellarWallet.Domain.Interfaces.Services;
 
-namespace StellarWallet.Infrastructure.Services
-{
-    public class EncryptionService : IEncryptionService
-    {
-        public string Encrypt(string text)
-        {
-            return BCrypt.Net.BCrypt.EnhancedHashPassword(text); ;
-        }
+namespace StellarWallet.Infrastructure.Services;
 
-        public bool Verify(string text, string hash)
-        {
-            return BCrypt.Net.BCrypt.EnhancedVerify(text, hash);
-        }
+public class EncryptionService : IEncryptionService
+{
+    public string Encrypt(string text)
+    {
+        return BCrypt.Net.BCrypt.EnhancedHashPassword(text);
+    }
+
+    public bool Verify(string text, string hash)
+    {
+        return BCrypt.Net.BCrypt.EnhancedVerify(text, hash);
     }
 }

--- a/StellarWallet.Infrastructure/Services/JwtService.cs
+++ b/StellarWallet.Infrastructure/Services/JwtService.cs
@@ -1,84 +1,83 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 using StellarWallet.Domain.Errors;
 using StellarWallet.Domain.Interfaces.Services;
 using StellarWallet.Domain.Result;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Text;
 
-namespace StellarWallet.Infrastructure.Services
+namespace StellarWallet.Infrastructure.Services;
+
+public class JwtService(IConfiguration config) : IJwtService
 {
-    public class JwtService(IConfiguration config) : IJwtService
+    private readonly string? secretKey = config.GetSection("Jwt").GetSection("Key").Value;
+    private readonly string? issuer = config.GetSection("Jwt").GetSection("Issuer").Value;
+    private readonly string? audience = config.GetSection("Jwt").GetSection("Audience").Value;
+
+    public Result<string, CustomError> CreateToken(string email, string role)
     {
-        private readonly string? secretKey = config.GetSection("Jwt").GetSection("Key").Value;
-        private readonly string? issuer = config.GetSection("Jwt").GetSection("Issuer").Value;
-        private readonly string? audience = config.GetSection("Jwt").GetSection("Audience").Value;
-
-        public Result<string, CustomError> CreateToken(string email, string role)
+        if (secretKey is null)
         {
-            if (secretKey is null)
-            {
-                return CustomError.NotFound("No secret key found.");
-            }
-
-            var keyBytes = Encoding.ASCII.GetBytes(secretKey);
-            var claims = new ClaimsIdentity();
-
-            claims.AddClaim(new Claim(ClaimTypes.NameIdentifier, email));
-            claims.AddClaim(new Claim(ClaimTypes.Role, role));
-
-            var tokenDescriptor = new SecurityTokenDescriptor
-            {
-                Subject = claims,
-                Expires = DateTime.UtcNow.AddYears(100),
-                SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(keyBytes), SecurityAlgorithms.HmacSha256Signature),
-                Issuer = issuer,
-                Audience = audience
-            };
-            var tokenHandler = new JwtSecurityTokenHandler();
-            var tokenConfig = tokenHandler.CreateToken(tokenDescriptor);
-
-            return tokenHandler.WriteToken(tokenConfig);
+            return CustomError.NotFound("No secret key found.");
         }
 
-        public Result<string, CustomError> DecodeToken(string token)
+        var keyBytes = Encoding.ASCII.GetBytes(secretKey);
+        var claims = new ClaimsIdentity();
+
+        claims.AddClaim(new Claim(ClaimTypes.NameIdentifier, email));
+        claims.AddClaim(new Claim(ClaimTypes.Role, role));
+
+        var tokenDescriptor = new SecurityTokenDescriptor
         {
-            var tokenHandler = new JwtSecurityTokenHandler();
+            Subject = claims,
+            Expires = DateTime.UtcNow.AddYears(100),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(keyBytes), SecurityAlgorithms.HmacSha256Signature),
+            Issuer = issuer,
+            Audience = audience
+        };
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var tokenConfig = tokenHandler.CreateToken(tokenDescriptor);
 
-            if (secretKey is null)
-            {
-                return CustomError.NotFound("No secret key found.");
-            }
+        return tokenHandler.WriteToken(tokenConfig);
+    }
 
-            var keyBytes = Encoding.ASCII.GetBytes(secretKey);
+    public Result<string, CustomError> DecodeToken(string token)
+    {
+        var tokenHandler = new JwtSecurityTokenHandler();
 
-            var validationParameters = new TokenValidationParameters
-            {
-                ValidateIssuerSigningKey = true,
-                IssuerSigningKey = new SymmetricSecurityKey(keyBytes),
-                ValidateIssuer = false,
-                ValidateAudience = false
-            };
-
-            var claimsPrincipal = tokenHandler.ValidateToken(token, validationParameters, out _);
-
-            if (claimsPrincipal is null)
-            {
-                return CustomError.NotFound("No claims found.");
-            }
-
-            var allClaims = claimsPrincipal.Claims.ToList();
-
-            var emailClaim = allClaims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier);
-            var roleClaim = allClaims.FirstOrDefault(c => c.Type == ClaimTypes.Role);
-
-            if (emailClaim is null || roleClaim is null)
-            {
-                return CustomError.NotFound("Email or role claim not found.");
-            }
-
-            return emailClaim.Value;
+        if (secretKey is null)
+        {
+            return CustomError.NotFound("No secret key found.");
         }
+
+        var keyBytes = Encoding.ASCII.GetBytes(secretKey);
+
+        var validationParameters = new TokenValidationParameters
+        {
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(keyBytes),
+            ValidateIssuer = false,
+            ValidateAudience = false
+        };
+
+        var claimsPrincipal = tokenHandler.ValidateToken(token, validationParameters, out _);
+
+        if (claimsPrincipal is null)
+        {
+            return CustomError.NotFound("No claims found.");
+        }
+
+        var allClaims = claimsPrincipal.Claims.ToList();
+
+        var emailClaim = allClaims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier);
+        var roleClaim = allClaims.FirstOrDefault(c => c.Type == ClaimTypes.Role);
+
+        if (emailClaim is null || roleClaim is null)
+        {
+            return CustomError.NotFound("Email or role claim not found.");
+        }
+
+        return emailClaim.Value;
     }
 }

--- a/StellarWallet.Infrastructure/Services/JwtService.cs
+++ b/StellarWallet.Infrastructure/Services/JwtService.cs
@@ -11,18 +11,18 @@ namespace StellarWallet.Infrastructure.Services;
 
 public class JwtService(IConfiguration config) : IJwtService
 {
-    private readonly string? secretKey = config.GetSection("Jwt").GetSection("Key").Value;
-    private readonly string? issuer = config.GetSection("Jwt").GetSection("Issuer").Value;
-    private readonly string? audience = config.GetSection("Jwt").GetSection("Audience").Value;
+    private readonly string? _secretKey = config.GetSection("Jwt").GetSection("Key").Value;
+    private readonly string? _issuer = config.GetSection("Jwt").GetSection("Issuer").Value;
+    private readonly string? _audience = config.GetSection("Jwt").GetSection("Audience").Value;
 
     public Result<string, CustomError> CreateToken(string email, string role)
     {
-        if (secretKey is null)
+        if (_secretKey is null)
         {
             return CustomError.NotFound("No secret key found.");
         }
 
-        var keyBytes = Encoding.ASCII.GetBytes(secretKey);
+        var keyBytes = Encoding.ASCII.GetBytes(_secretKey);
         var claims = new ClaimsIdentity();
 
         claims.AddClaim(new Claim(ClaimTypes.NameIdentifier, email));
@@ -32,9 +32,12 @@ public class JwtService(IConfiguration config) : IJwtService
         {
             Subject = claims,
             Expires = DateTime.UtcNow.AddYears(100),
-            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(keyBytes), SecurityAlgorithms.HmacSha256Signature),
-            Issuer = issuer,
-            Audience = audience
+            SigningCredentials = new SigningCredentials(
+                new SymmetricSecurityKey(keyBytes),
+                SecurityAlgorithms.HmacSha256Signature
+            ),
+            Issuer = _issuer,
+            Audience = _audience,
         };
         var tokenHandler = new JwtSecurityTokenHandler();
         var tokenConfig = tokenHandler.CreateToken(tokenDescriptor);
@@ -46,19 +49,19 @@ public class JwtService(IConfiguration config) : IJwtService
     {
         var tokenHandler = new JwtSecurityTokenHandler();
 
-        if (secretKey is null)
+        if (_secretKey is null)
         {
             return CustomError.NotFound("No secret key found.");
         }
 
-        var keyBytes = Encoding.ASCII.GetBytes(secretKey);
+        var keyBytes = Encoding.ASCII.GetBytes(_secretKey);
 
         var validationParameters = new TokenValidationParameters
         {
             ValidateIssuerSigningKey = true,
             IssuerSigningKey = new SymmetricSecurityKey(keyBytes),
             ValidateIssuer = false,
-            ValidateAudience = false
+            ValidateAudience = false,
         };
 
         var claimsPrincipal = tokenHandler.ValidateToken(token, validationParameters, out _);

--- a/StellarWallet.Infrastructure/Services/StellarService.cs
+++ b/StellarWallet.Infrastructure/Services/StellarService.cs
@@ -8,164 +8,163 @@ using StellarWallet.Domain.Result;
 using StellarWallet.Domain.Structs;
 using StellarWallet.Infrastructure.Utilities;
 
-namespace StellarWallet.Infrastructure.Services
+namespace StellarWallet.Infrastructure.Services;
+
+public class StellarService : IBlockchainService
 {
-    public class StellarService : IBlockchainService
+    private readonly string _horizonUrl;
+    private readonly Network _network;
+    private readonly Server _server;
+    private const string _stellarNativeAsset = "native";
+
+    public StellarService()
     {
-        private readonly string _horizonUrl;
-        private readonly Network _network;
-        private readonly Server _server;
-        private const string _stellarNativeAsset = "native";
+        var environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "test";
+        _horizonUrl = AppSettingsVariables.GetSettingVariable(StellarConstants.Section, StellarConstants.HorizonUrl, environmentName);
+        _network = new Network(AppSettingsVariables.GetSettingVariable(StellarConstants.Section, StellarConstants.Passphrase, environmentName));
+        _server = new Server(AppSettingsVariables.GetSettingVariable(StellarConstants.Section, StellarConstants.HorizonUrl, environmentName));
+    }
 
-        public StellarService()
+    public Result<BlockchainAccount, CustomError> CreateAccount(int userId)
+    {
+        var keyPair = CreateKeyPair().Value;
+        return new BlockchainAccount(PublicKey: keyPair.PublicKey, SecretKey: keyPair.SecretKey, userId);
+    }
+
+    public Result<AccountKeyPair, CustomError> CreateKeyPair()
+    {
+        var keyPair = KeyPair.Random();
+
+        return new AccountKeyPair
         {
-            string environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "test";
-            _horizonUrl = AppSettingsVariables.GetSettingVariable(StellarConstants.Section, StellarConstants.HorizonUrl, environmentName);
-            _network = new Network(AppSettingsVariables.GetSettingVariable(StellarConstants.Section, StellarConstants.Passphrase, environmentName));
-            _server = new Server(AppSettingsVariables.GetSettingVariable(StellarConstants.Section, StellarConstants.HorizonUrl, environmentName));
+            PublicKey = keyPair.AccountId,
+            SecretKey = keyPair.SecretSeed
+        };
+    }
+
+    public async Task<Result<bool, CustomError>> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount, string assetIssuer, string assetCode, string memo)
+    {
+        var sourceKeypair = KeyPair.FromSecretSeed(sourceSecretKey);
+
+        AccountResponse sourceAccountResponse;
+
+        sourceAccountResponse = await _server.Accounts.Account(sourceKeypair.AccountId);
+
+        var destinationKeyPair = KeyPair.FromAccountId(destinationPublicKey);
+
+        if (sourceAccountResponse is null || destinationKeyPair is null)
+        {
+            return CustomError.ExternalServiceError("Invalid account");
         }
 
-        public Result<BlockchainAccount, CustomError> CreateAccount(int userId)
+        Account sourceAccount = new(sourceKeypair.AccountId, sourceAccountResponse.SequenceNumber);
+
+        var asset = assetIssuer == _stellarNativeAsset ? (Asset)new AssetTypeNative() : Asset.CreateNonNativeAsset(assetCode, assetIssuer);
+
+        var paymentOperation = new PaymentOperation.Builder(destinationKeyPair, asset, amount).SetSourceAccount(sourceAccount.KeyPair).Build();
+
+        var transaction = new TransactionBuilder(sourceAccount)
+           .AddOperation(paymentOperation)
+           .AddMemo(new MemoText(memo))
+           .Build();
+
+        transaction.Sign(sourceKeypair, _network);
+
+        var response = await _server.SubmitTransaction(transaction);
+
+        if (response.IsSuccess())
         {
-            AccountKeyPair keyPair = CreateKeyPair().Value;
-            return new BlockchainAccount(PublicKey: keyPair.PublicKey, SecretKey: keyPair.SecretKey, userId);
+            return response.IsSuccess();
         }
 
-        public Result<AccountKeyPair, CustomError> CreateKeyPair()
+        return CustomError.ExternalServiceError("Transaction failed");
+    }
+
+    public async Task<Result<BlockchainPayment[], CustomError>> GetPayments(string publicKey)
+    {
+        var payments = new List<BlockchainPayment>();
+
+        try
         {
-            KeyPair keyPair = KeyPair.Random();
+            var server = new Server(_horizonUrl);
+            var paymentsRequestBuilder = server.Payments.ForAccount(publicKey);
+            var page = await paymentsRequestBuilder.Execute();
 
-            return new AccountKeyPair
+            while (true)
             {
-                PublicKey = keyPair.AccountId,
-                SecretKey = keyPair.SecretSeed
-            };
-        }
-
-        public async Task<Result<bool, CustomError>> SendPayment(string sourceSecretKey, string destinationPublicKey, string amount, string assetIssuer, string assetCode, string memo)
-        {
-            var sourceKeypair = KeyPair.FromSecretSeed(sourceSecretKey);
-
-            AccountResponse sourceAccountResponse;
-
-            sourceAccountResponse = await _server.Accounts.Account(sourceKeypair.AccountId);
-
-            var destinationKeyPair = KeyPair.FromAccountId(destinationPublicKey);
-
-            if (sourceAccountResponse is null || destinationKeyPair is null)
-            {
-                return CustomError.ExternalServiceError("Invalid account");
-            }
-
-            Account sourceAccount = new(sourceKeypair.AccountId, sourceAccountResponse.SequenceNumber);
-
-            var asset = assetIssuer == _stellarNativeAsset ? (Asset)new AssetTypeNative() : Asset.CreateNonNativeAsset(assetCode, assetIssuer);
-
-            PaymentOperation paymentOperation = new PaymentOperation.Builder(destinationKeyPair, asset, amount).SetSourceAccount(sourceAccount.KeyPair).Build();
-
-            Transaction transaction = new TransactionBuilder(sourceAccount)
-               .AddOperation(paymentOperation)
-               .AddMemo(new MemoText(memo))
-               .Build();
-
-            transaction.Sign(sourceKeypair, _network);
-
-            SubmitTransactionResponse response = await _server.SubmitTransaction(transaction);
-
-            if (response.IsSuccess())
-            {
-                return response.IsSuccess();
-            }
-
-            return CustomError.ExternalServiceError("Transaction failed");
-        }
-
-        public async Task<Result<BlockchainPayment[], CustomError>> GetPayments(string publicKey)
-        {
-            var payments = new List<BlockchainPayment>();
-
-            try
-            {
-                var server = new Server(_horizonUrl);
-                var paymentsRequestBuilder = server.Payments.ForAccount(publicKey);
-                var page = await paymentsRequestBuilder.Execute();
-
-                while (true)
+                foreach (var record in page.Records.OfType<PaymentOperationResponse>())
                 {
-                    foreach (var record in page.Records.OfType<PaymentOperationResponse>())
+                    payments.Add(new BlockchainPayment
                     {
-                        payments.Add(new BlockchainPayment
-                        {
-                            Id = record.TransactionHash,
-                            From = record.From,
-                            To = record.To,
-                            Amount = record.Amount,
-                            Asset = record.Asset is AssetTypeNative ? _stellarNativeAsset : ((AssetTypeCreditAlphaNum)record.Asset).Code,
-                            CreatedAt = record.CreatedAt.ToString(),
-                            WasSuccessful = record.TransactionSuccessful
-                        });
-                    }
-
-                    if (page.Records.Count == 0)
-                    {
-                        break;
-                    }
-
-                    page = await paymentsRequestBuilder.Cursor(page.Records[^1].PagingToken).Execute();
-                }
-            }
-            catch (Exception e)
-            {
-                return CustomError.ExternalServiceError("Stellar Error " + e.Message);
-            }
-
-            return payments.ToArray();
-        }
-
-        public async Task<Result<bool, CustomError>> GetTestFunds(string publicKey)
-        {
-            try
-            {
-                var friendBotRequest = new HttpRequestMessage(HttpMethod.Get, $"{_horizonUrl}/friendbot?addr={publicKey}");
-                var response = await new HttpClient().SendAsync(friendBotRequest);
-
-                if (!response.IsSuccessStatusCode)
-                {
-                    return CustomError.ExternalServiceError("Test funds failed");
-                }
-
-                return Result<bool, CustomError>.Success(true);
-            }
-            catch (Exception e)
-            {
-                return CustomError.ExternalServiceError("Stellar Error " + e.Message);
-            }
-        }
-
-        public async Task<Result<List<AccountBalances>, CustomError>> GetBalances(string publicKey)
-        {
-            try
-            {
-                var balances = new List<AccountBalances>();
-
-                var account = await _server.Accounts.Account(publicKey);
-
-                foreach (var balance in account.Balances)
-                {
-                    balances.Add(new AccountBalances
-                    {
-                        Asset = balance.Asset is AssetTypeNative ? _stellarNativeAsset : ((AssetTypeCreditAlphaNum)balance.Asset).Code,
-                        Amount = balance.BalanceString,
-                        Issuer = balance.Asset is AssetTypeNative ? _stellarNativeAsset : ((AssetTypeCreditAlphaNum)balance.Asset).Issuer
+                        Id = record.TransactionHash,
+                        From = record.From,
+                        To = record.To,
+                        Amount = record.Amount,
+                        Asset = record.Asset is AssetTypeNative ? _stellarNativeAsset : ((AssetTypeCreditAlphaNum)record.Asset).Code,
+                        CreatedAt = record.CreatedAt.ToString(),
+                        WasSuccessful = record.TransactionSuccessful
                     });
                 }
 
-                return balances;
+                if (page.Records.Count == 0)
+                {
+                    break;
+                }
+
+                page = await paymentsRequestBuilder.Cursor(page.Records[^1].PagingToken).Execute();
             }
-            catch (Exception e)
+        }
+        catch (Exception e)
+        {
+            return CustomError.ExternalServiceError("Stellar Error " + e.Message);
+        }
+
+        return payments.ToArray();
+    }
+
+    public async Task<Result<bool, CustomError>> GetTestFunds(string publicKey)
+    {
+        try
+        {
+            var friendBotRequest = new HttpRequestMessage(HttpMethod.Get, $"{_horizonUrl}/friendbot?addr={publicKey}");
+            var response = await new HttpClient().SendAsync(friendBotRequest);
+
+            if (!response.IsSuccessStatusCode)
             {
-                return CustomError.ExternalServiceError("Stellar Error " + e.Message);
+                return CustomError.ExternalServiceError("Test funds failed");
             }
+
+            return Result<bool, CustomError>.Success(true);
+        }
+        catch (Exception e)
+        {
+            return CustomError.ExternalServiceError("Stellar Error " + e.Message);
+        }
+    }
+
+    public async Task<Result<List<AccountBalances>, CustomError>> GetBalances(string publicKey)
+    {
+        try
+        {
+            var balances = new List<AccountBalances>();
+
+            var account = await _server.Accounts.Account(publicKey);
+
+            foreach (var balance in account.Balances)
+            {
+                balances.Add(new AccountBalances
+                {
+                    Asset = balance.Asset is AssetTypeNative ? _stellarNativeAsset : ((AssetTypeCreditAlphaNum)balance.Asset).Code,
+                    Amount = balance.BalanceString,
+                    Issuer = balance.Asset is AssetTypeNative ? _stellarNativeAsset : ((AssetTypeCreditAlphaNum)balance.Asset).Issuer
+                });
+            }
+
+            return balances;
+        }
+        catch (Exception e)
+        {
+            return CustomError.ExternalServiceError("Stellar Error " + e.Message);
         }
     }
 }

--- a/StellarWallet.Infrastructure/StellarWallet.Infrastructure.csproj
+++ b/StellarWallet.Infrastructure/StellarWallet.Infrastructure.csproj
@@ -41,10 +41,18 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" /> 
     <PackageReference Include="stellar-dotnet-sdk" Version="9.1.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.3.0.106239">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\StellarWallet.Domain\StellarWallet.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\.editorconfig" />
   </ItemGroup>
 
 </Project>

--- a/StellarWallet.Infrastructure/Utilities/AppSettingsVariables.cs
+++ b/StellarWallet.Infrastructure/Utilities/AppSettingsVariables.cs
@@ -1,47 +1,46 @@
 ﻿using Microsoft.Extensions.Configuration;
 
-namespace StellarWallet.Infrastructure.Utilities
+namespace StellarWallet.Infrastructure.Utilities;
+
+public static class AppSettingsVariables
 {
-    public static class AppSettingsVariables
+    public static IConfigurationRoot BuildConfig(string? environment)
     {
-        public static IConfigurationRoot BuildConfig(string? environment)
-        {
-            string settedEnvironment = SetEnvironment(environment);
+        var settedEnvironment = SetEnvironment(environment);
 
-            string? directory;
+        string? directory;
 
-            if (settedEnvironment == "test")
-                directory = Path.Combine("..", "..", "..", "..", "StellarWallet.WebApi");
-            else
-                directory = Directory.GetCurrentDirectory();
+        if (settedEnvironment == "test")
+            directory = Path.Combine("..", "..", "..", "..", "StellarWallet.WebApi");
+        else
+            directory = Directory.GetCurrentDirectory();
 
-            var configurationBuilder = new ConfigurationBuilder()
-                .SetBasePath(Path.GetFullPath(directory));
+        var configurationBuilder = new ConfigurationBuilder()
+            .SetBasePath(Path.GetFullPath(directory));
 
-            if (File.Exists($"appsettings.{settedEnvironment}.json"))
-                configurationBuilder.AddJsonFile($"appsettings.{settedEnvironment}.json", optional: false);
-            else
-                throw new FileNotFoundException("Configuration file not found");
+        if (File.Exists($"appsettings.{settedEnvironment}.json"))
+            configurationBuilder.AddJsonFile($"appsettings.{settedEnvironment}.json", optional: false);
+        else
+            throw new FileNotFoundException("Configuration file not found");
 
-            return configurationBuilder.Build();
-        }
-
-        public static string GetConnectionString(string? environment)
-        {
-            return BuildConfig(SetEnvironment(environment)).GetConnectionString("StellarWallet") ?? throw new InvalidOperationException("Undefined connection string");
-        }
-
-        public static string GetSettingVariable(string sectionName, string variableName, string? environment)
-        {
-            return BuildConfig(SetEnvironment(environment)).GetSection(sectionName).GetValue<string>(variableName) ?? throw new InvalidOperationException("Undefined variable");
-        }
-
-        private readonly static Func<string?, string> SetEnvironment = (string? environment) =>
-        {
-            if (string.IsNullOrEmpty(environment))
-                return Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "test";
-            else
-                return environment;
-        };
+        return configurationBuilder.Build();
     }
+
+    public static string GetConnectionString(string? environment)
+    {
+        return BuildConfig(SetEnvironment(environment)).GetConnectionString("StellarWallet") ?? throw new InvalidOperationException("Undefined connection string");
+    }
+
+    public static string GetSettingVariable(string sectionName, string variableName, string? environment)
+    {
+        return BuildConfig(SetEnvironment(environment)).GetSection(sectionName).GetValue<string>(variableName) ?? throw new InvalidOperationException("Undefined variable");
+    }
+
+    private static readonly Func<string?, string> SetEnvironment = (string? environment) =>
+    {
+        if (string.IsNullOrEmpty(environment))
+            return Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "test";
+        else
+            return environment;
+    };
 }

--- a/StellarWallet.Infrastructure/Utilities/StellarConstants.cs
+++ b/StellarWallet.Infrastructure/Utilities/StellarConstants.cs
@@ -1,9 +1,8 @@
-﻿namespace StellarWallet.Infrastructure.Utilities
+﻿namespace StellarWallet.Infrastructure.Utilities;
+
+public static class StellarConstants
 {
-    public static class StellarConstants
-    {
-        public const string Section = "Stellar";
-        public const string HorizonUrl = "HorizonUrl";
-        public const string Passphrase = "Passphrase";
-    }
+    public const string Section = "Stellar";
+    public const string HorizonUrl = "HorizonUrl";
+    public const string Passphrase = "Passphrase";
 }

--- a/StellarWallet.IntegrationTest/StellarWallet.IntegrationTest.csproj
+++ b/StellarWallet.IntegrationTest/StellarWallet.IntegrationTest.csproj
@@ -22,6 +22,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.3.0.106239">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -30,6 +34,10 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\.editorconfig" />
   </ItemGroup>
 
 </Project>

--- a/StellarWallet.IntegrationTest/StellarWalletWebApplicationFactory.cs
+++ b/StellarWallet.IntegrationTest/StellarWalletWebApplicationFactory.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using StellarWallet.Infrastructure;
@@ -16,7 +15,6 @@ internal class StellarWalletWebApplicationFactory : WebApplicationFactory<Progra
         builder.ConfigureTestServices(services =>
         {
             services.RemoveAll(typeof(DbContextOptions<DatabaseContext>));
-            var connectionString = GetConnectionString();
 
             services.AddDbContext<DatabaseContext>(options =>
             {
@@ -26,15 +24,6 @@ internal class StellarWalletWebApplicationFactory : WebApplicationFactory<Progra
             var dbContext = CreateDatabaseContext(services);
             dbContext.Database.EnsureCreated();
         });
-    }
-
-    private static string? GetConnectionString()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddUserSecrets<StellarWalletWebApplicationFactory>()
-            .Build();
-
-        return configuration.GetConnectionString("StellarWalletTestDatabase");
     }
 
     private static DatabaseContext CreateDatabaseContext(IServiceCollection services)

--- a/StellarWallet.IntegrationTest/UserControllerTests.cs
+++ b/StellarWallet.IntegrationTest/UserControllerTests.cs
@@ -1,37 +1,36 @@
+using System.Net.Http.Json;
 using StellarWallet.Application.Dtos.Requests;
 using StellarWallet.Application.Dtos.Responses;
 using StellarWallet.Domain.Errors;
 using StellarWallet.Domain.Result;
-using System.Net.Http.Json;
 
-namespace StellarWallet.IntegrationTest
+namespace StellarWallet.IntegrationTest;
+
+public class UserControllerTests
 {
-    public class UserControllerTests
+    public UserControllerTests()
     {
-        public UserControllerTests()
-        {
-            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "test");
-        }
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "test");
+    }
 
-        [Fact]
-        public async Task When_ValidUserCreationDto_Expected_ReturnLoggedDto()
-        {
-            var application = new StellarWalletWebApplicationFactory();
+    [Fact]
+    public async Task When_ValidUserCreationDto_Expected_ReturnLoggedDto()
+    {
+        var application = new StellarWalletWebApplicationFactory();
 
-            UserCreationDto request = new("John", "Doe", "my.mail2@test.com", "MyPassword123.", null, null);
+        UserCreationDto request = new("John", "Doe", "my.mail2@test.com", "MyPassword123.", null, null);
 
-            var client = application.CreateClient();
+        var client = application.CreateClient();
 
-            var response = await client.PostAsJsonAsync("/User", request);
+        var response = await client.PostAsJsonAsync("/User", request);
 
-            response.EnsureSuccessStatusCode();
-            var responseContent = await response.Content.ReadAsStringAsync();
-            var createUserResponse = await response.Content.ReadFromJsonAsync<Result<LoggedDto, CustomError>>();
+        response.EnsureSuccessStatusCode();
 
-            Assert.True(createUserResponse?.IsSuccess);
-            Assert.Null(createUserResponse?.Value.Token);
-            Assert.NotNull(createUserResponse?.Value.PublicKey);
-            Assert.Null(createUserResponse.Error);
-        }
+        var createUserResponse = await response.Content.ReadFromJsonAsync<Result<LoggedDto, CustomError>>();
+
+        Assert.True(createUserResponse?.IsSuccess);
+        Assert.Null(createUserResponse?.Value.Token);
+        Assert.NotNull(createUserResponse?.Value.PublicKey);
+        Assert.Null(createUserResponse.Error);
     }
 }

--- a/StellarWallet.UnitTest/Application/Services/AuthServiceTest.cs
+++ b/StellarWallet.UnitTest/Application/Services/AuthServiceTest.cs
@@ -8,114 +8,113 @@ using StellarWallet.Domain.Interfaces.Persistence;
 using StellarWallet.Domain.Interfaces.Services;
 using StellarWallet.Domain.Result;
 
-namespace StellarWallet.UnitTest.Application.Services
+namespace StellarWallet.UnitTest.Application.Services;
+
+public class AuthServiceTest
 {
-    public class AuthServiceTest
+    [Fact]
+    public async Task When_ValidLoginDto_Expected_ReturnLoggedDto()
     {
-        [Fact]
-        public async Task When_ValidLoginDto_Expected_ReturnLoggedDto()
-        {
-            var mockUnitOfWork = new Mock<IUnitOfWork>();
-            var mockJwtService = new Mock<IJwtService>();
-            var mockEncryptionService = new Mock<IEncryptionService>();
+        var mockUnitOfWork = new Mock<IUnitOfWork>();
+        var mockJwtService = new Mock<IJwtService>();
+        var mockEncryptionService = new Mock<IEncryptionService>();
 
-            var sut = new AuthService(mockJwtService.Object, mockEncryptionService.Object, mockUnitOfWork.Object);
+        var sut = new AuthService(mockJwtService.Object, mockEncryptionService.Object, mockUnitOfWork.Object);
 
-            var loggedDto = new LoggedDto(true, "token", "GBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA");
+        var loggedDto = new LoggedDto(true, "token", "GBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA");
 
-            var loginDto = new LoginDto("john.doe@mail.com", "MyPassword123.");
+        var loginDto = new LoginDto("john.doe@mail.com", "MyPassword123.");
 
-            mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), loginDto.Email)).ReturnsAsync(new User(
-                "John",
-                "Doe",
-                "john.doe@mail.com",
-                "EncryptedPassword",
-                "GBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA",
-                "SC6KTRKOT33RRH2KXK2BMGJWJ7TE5NQGRE5NIWTBGNMSPLKGQ2C63KDB"
-            ));
+        mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), loginDto.Email)).ReturnsAsync(new User(
+            "John",
+            "Doe",
+            "john.doe@mail.com",
+            "EncryptedPassword",
+            "GBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA",
+            "SC6KTRKOT33RRH2KXK2BMGJWJ7TE5NQGRE5NIWTBGNMSPLKGQ2C63KDB"
+        ));
 
-            mockEncryptionService.Setup(x => x.Verify(loginDto.Password, "EncryptedPassword")).Returns(true);
+        mockEncryptionService.Setup(x => x.Verify(loginDto.Password, "EncryptedPassword")).Returns(true);
 
-            mockJwtService.Setup(x => x.CreateToken("john.doe@mail.com", "user")).Returns(Result<string, CustomError>.Success("token"));
+        mockJwtService.Setup(x => x.CreateToken("john.doe@mail.com", "user")).Returns(Result<string, CustomError>.Success("token"));
 
-            var result = await sut.Login(loginDto);
+        var result = await sut.Login(loginDto);
 
-            Assert.True(result.Value.Success);
-            Assert.Equal(loggedDto.Token, result.Value.Token);
-            Assert.Equal(loggedDto.PublicKey, result.Value.PublicKey);
-        }
+        Assert.True(result.Value.Success);
+        Assert.Equal(loggedDto.Token, result.Value.Token);
+        Assert.Equal(loggedDto.PublicKey, result.Value.PublicKey);
+    }
 
-        [Fact]
-        public async Task When_InvalidLoginDto_Expected_UnsuccessfulResponse()
-        {
-            var mockUnitOfWork = new Mock<IUnitOfWork>();
-            var mockJwtService = new Mock<IJwtService>();
-            var mockEncryptionService = new Mock<IEncryptionService>();
+    [Fact]
+    public async Task When_InvalidLoginDto_Expected_UnsuccessfulResponse()
+    {
+        var mockUnitOfWork = new Mock<IUnitOfWork>();
+        var mockJwtService = new Mock<IJwtService>();
+        var mockEncryptionService = new Mock<IEncryptionService>();
 
-            var sut = new AuthService(mockJwtService.Object, mockEncryptionService.Object, mockUnitOfWork.Object);
+        var sut = new AuthService(mockJwtService.Object, mockEncryptionService.Object, mockUnitOfWork.Object);
 
-            Mock<User> user = new("John", "Doe", "john.doe@mail.com", "EncryptedPassword", "GBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA", "SC6KTRKOT33RRH2KXK2BMGJWJ7TE5NQGRE5NIWTBGNMSPLKGQ2C63KDB", "admin");
+        Mock<User> user = new("John", "Doe", "john.doe@mail.com", "EncryptedPassword", "GBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA", "SC6KTRKOT33RRH2KXK2BMGJWJ7TE5NQGRE5NIWTBGNMSPLKGQ2C63KDB", "admin");
 
 
-            mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), "john.doe@mail.com")).ReturnsAsync(user.Object);
+        mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), "john.doe@mail.com")).ReturnsAsync(user.Object);
 
-            var loginDto = new LoginDto("john.doe@mail.com", "MyPassword123.");
-            mockEncryptionService.Setup(x => x.Verify(loginDto.Password, "EncryptedPassword")).Returns(false);
+        var loginDto = new LoginDto("john.doe@mail.com", "MyPassword123.");
+        mockEncryptionService.Setup(x => x.Verify(loginDto.Password, "EncryptedPassword")).Returns(false);
 
-            var result = await sut.Login(loginDto);
+        var result = await sut.Login(loginDto);
 
-            Assert.False(result.IsSuccess);
-        }
+        Assert.False(result.IsSuccess);
+    }
 
-        [Fact]
-        public void When_UnexistingUser_Expected_ThrowException()
-        {
-            var mockUnitOfWork = new Mock<IUnitOfWork>();
-            var mockJwtService = new Mock<IJwtService>();
-            var mockEncryptionService = new Mock<IEncryptionService>();
+    [Fact]
+    public void When_UnexistingUser_Expected_ThrowException()
+    {
+        var mockUnitOfWork = new Mock<IUnitOfWork>();
+        var mockJwtService = new Mock<IJwtService>();
+        var mockEncryptionService = new Mock<IEncryptionService>();
 
-            var sut = new AuthService(mockJwtService.Object, mockEncryptionService.Object, mockUnitOfWork.Object);
+        var sut = new AuthService(mockJwtService.Object, mockEncryptionService.Object, mockUnitOfWork.Object);
 
-            var loginDto = new LoginDto("john.doe@mail.com", "MyPassword123.");
-            mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), loginDto.Email)).ReturnsAsync((User?)null);
+        var loginDto = new LoginDto("john.doe@mail.com", "MyPassword123.");
+        mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), loginDto.Email)).ReturnsAsync((User?)null);
 
-            Assert.ThrowsAsync<Exception>(() => sut.Login(loginDto));
-        }
+        Assert.ThrowsAsync<Exception>(() => sut.Login(loginDto));
+    }
 
-        [Fact]
-        public void When_ValidJwt_Expected_ReturnTrue()
-        {
-            var mockUnitOfWork = new Mock<IUnitOfWork>();
-            var mockJwtService = new Mock<IJwtService>();
-            var mockEncryptionService = new Mock<IEncryptionService>();
+    [Fact]
+    public void When_ValidJwt_Expected_ReturnTrue()
+    {
+        var mockUnitOfWork = new Mock<IUnitOfWork>();
+        var mockJwtService = new Mock<IJwtService>();
+        var mockEncryptionService = new Mock<IEncryptionService>();
 
-            var sut = new AuthService(mockJwtService.Object, mockEncryptionService.Object, mockUnitOfWork.Object);
+        var sut = new AuthService(mockJwtService.Object, mockEncryptionService.Object, mockUnitOfWork.Object);
 
-            var jwt = "token";
-            var email = "john.doe@mail.com";
+        var jwt = "token";
+        var email = "john.doe@mail.com";
 
-            mockJwtService.Setup(x => x.DecodeToken(jwt)).Returns(Result<string, CustomError>.Success(email));
+        mockJwtService.Setup(x => x.DecodeToken(jwt)).Returns(Result<string, CustomError>.Success(email));
 
-            var result = sut.AuthenticateEmail(jwt, email);
+        var result = sut.AuthenticateEmail(jwt, email);
 
-            Assert.True(result.Value);
-        }
+        Assert.True(result.Value);
+    }
 
-        [Fact]
-        public void When_InvalidJwt_Expected_ThrowException()
-        {
-            var mockUnitOfWork = new Mock<IUnitOfWork>();
-            var mockJwtService = new Mock<IJwtService>();
-            var mockEncryptionService = new Mock<IEncryptionService>();
+    [Fact]
+    public void When_InvalidJwt_Expected_ThrowException()
+    {
+        var mockUnitOfWork = new Mock<IUnitOfWork>();
+        var mockJwtService = new Mock<IJwtService>();
+        var mockEncryptionService = new Mock<IEncryptionService>();
 
-            var sut = new AuthService(mockJwtService.Object, mockEncryptionService.Object, mockUnitOfWork.Object);
+        var sut = new AuthService(mockJwtService.Object, mockEncryptionService.Object, mockUnitOfWork.Object);
 
-            var jwt = "token";
-            var email = "john.doe@mail.com";
+        var jwt = "token";
+        var email = "john.doe@mail.com";
 
-            mockJwtService.Setup(x => x.DecodeToken(jwt)).Throws(new Exception("Email or role claim not found"));
+        mockJwtService.Setup(x => x.DecodeToken(jwt)).Throws(new Exception("Email or role claim not found"));
 
-            Assert.Throws<Exception>(() => sut.AuthenticateEmail(jwt, email));
-        }
+        Assert.Throws<Exception>(() => sut.AuthenticateEmail(jwt, email));
     }
 }

--- a/StellarWallet.UnitTest/Application/Services/TransactionServiceTest.cs
+++ b/StellarWallet.UnitTest/Application/Services/TransactionServiceTest.cs
@@ -9,210 +9,209 @@ using StellarWallet.Domain.Interfaces.Services;
 using StellarWallet.Domain.Result;
 using StellarWallet.Domain.Structs;
 
-namespace StellarWallet.UnitTest.Application.Services
+namespace StellarWallet.UnitTest.Application.Services;
+
+public class TransactionServiceTest
 {
-    public class TransactionServiceTest
+    private readonly Mock<IBlockchainService> _mockBlockchainService = new();
+    private readonly Mock<IJwtService> _mockJwtService = new();
+    private readonly Mock<IUnitOfWork> _mockUnitOfWork = new();
+    private readonly Mock<IAuthService> _mockAuthService = new();
+    private readonly TransactionService _sut;
+    private const string JWT = "token";
+    private readonly User _validUser = new("John", "Doe", "john.doe@mail.com", "EncryptedPassword", "GBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA", "SBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA", "admin");
+
+    public TransactionServiceTest()
     {
-        private readonly Mock<IBlockchainService> _mockBlockchainService = new();
-        private readonly Mock<IJwtService> _mockJwtService = new();
-        private readonly Mock<IUnitOfWork> _mockUnitOfWork = new();
-        private readonly Mock<IAuthService> _mockAuthService = new();
-        private readonly TransactionService _sut;
-        private const string JWT = "token";
-        private readonly User _validUser = new("John", "Doe", "john.doe@mail.com", "EncryptedPassword", "GBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA", "SBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA", "admin");
+        _sut = new TransactionService(_mockBlockchainService.Object, _mockJwtService.Object, _mockAuthService.Object, _mockUnitOfWork.Object);
+    }
 
-        public TransactionServiceTest()
-        {
-            _sut = new TransactionService(_mockBlockchainService.Object, _mockJwtService.Object, _mockAuthService.Object, _mockUnitOfWork.Object);
-        }
+    [Fact]
+    public async Task When_ValidJwt_Expected_CreateAccount()
+    {
+        _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
+        _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync(_validUser);
+        _mockBlockchainService.Setup(x => x.CreateAccount(_validUser.Id)).Returns(new BlockchainAccount(_validUser.PublicKey, _validUser.SecretKey, _validUser.Id));
 
-        [Fact]
-        public async Task When_ValidJwt_Expected_CreateAccount()
-        {
-            _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
-            _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync(_validUser);
-            _mockBlockchainService.Setup(x => x.CreateAccount(_validUser.Id)).Returns(new BlockchainAccount(_validUser.PublicKey, _validUser.SecretKey, _validUser.Id));
+        var result = await _sut.CreateAccount(JWT);
 
-            var result = await _sut.CreateAccount(JWT);
+        Assert.True(result.Value.PublicKey == _validUser.PublicKey);
+        Assert.True(result.Value.SecretKey == _validUser.SecretKey);
+        Assert.True(result.Value.UserId == _validUser.Id);
+    }
 
-            Assert.True(result.Value.PublicKey == _validUser.PublicKey);
-            Assert.True(result.Value.SecretKey == _validUser.SecretKey);
-            Assert.True(result.Value.UserId == _validUser.Id);
-        }
+    [Fact]
+    public async Task When_UnexistingUser_Expected_UnsuccessfulResponse()
+    {
+        _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
+        _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync((User?)null);
 
-        [Fact]
-        public async Task When_UnexistingUser_Expected_UnsuccessfulResponse()
-        {
-            _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
-            _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync((User)null);
+        var result = await _sut.CreateAccount(JWT);
 
-            var result = await _sut.CreateAccount(JWT);
+        Assert.True(!result.IsSuccess);
+    }
 
-            Assert.True(!result.IsSuccess);
-        }
+    [Fact]
+    public async Task When_InvalidJwt_Expected_ThrowException()
+    {
+        _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
+        _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync(_validUser);
+        _mockBlockchainService.Setup(x => x.CreateAccount(_validUser.Id)).Returns(new BlockchainAccount(_validUser.PublicKey, _validUser.SecretKey, _validUser.Id));
 
-        [Fact]
-        public async Task When_InvalidJwt_Expected_ThrowException()
-        {
-            _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
-            _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync(_validUser);
-            _mockBlockchainService.Setup(x => x.CreateAccount(_validUser.Id)).Returns(new BlockchainAccount(_validUser.PublicKey, _validUser.SecretKey, _validUser.Id));
+        await Assert.ThrowsAsync<NullReferenceException>(() => _sut.CreateAccount("invalidToken"));
+    }
 
-            await Assert.ThrowsAsync<NullReferenceException>(() => _sut.CreateAccount("invalidToken"));
-        }
+    [Fact]
+    public async Task When_ValidSendPayment_Expected_True()
+    {
+        var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, string.Empty, string.Empty, "test_memo");
+        _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
+        _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync(_validUser);
+        _mockAuthService.Setup(x => x.AuthenticateEmail(JWT, _validUser.Email)).Returns(Result<bool, CustomError>.Success(true));
+        _mockBlockchainService.Setup(x => x.SendPayment(_validUser.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), string.Empty, string.Empty, "test_memo")).ReturnsAsync(Result<bool, CustomError>.Success(true));
 
-        [Fact]
-        public async Task When_ValidSendPayment_Expected_True()
-        {
-            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, string.Empty, string.Empty, "test_memo");
-            _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
-            _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync(_validUser);
-            _mockAuthService.Setup(x => x.AuthenticateEmail(JWT, _validUser.Email)).Returns(Result<bool, CustomError>.Success(true));
-            _mockBlockchainService.Setup(x => x.SendPayment(_validUser.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), string.Empty, string.Empty, "test_memo")).ReturnsAsync(Result<bool, CustomError>.Success(true));
+        var result = await _sut.SendPayment(sendPaymentDto, JWT);
 
-            var result = await _sut.SendPayment(sendPaymentDto, JWT);
+        Assert.True(result.IsSuccess);
+    }
 
-            Assert.True(result.IsSuccess);
-        }
+    [Fact]
+    public async Task When_UnexistingUserSendPayment_Expected_UnsuccessfulResponse()
+    {
+        var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, string.Empty, string.Empty, "test_memo");
+        _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
+        _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync((User?)null);
 
-        [Fact]
-        public async Task When_UnexistingUserSendPayment_Expected_UnsuccessfulResponse()
-        {
-            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, string.Empty, string.Empty, "test_memo");
-            _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
-            _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync((User)null);
+        var result = await _sut.SendPayment(sendPaymentDto, JWT);
 
-            var result = await _sut.SendPayment(sendPaymentDto, JWT);
+        Assert.True(!result.IsSuccess);
+    }
 
-            Assert.True(!result.IsSuccess);
-        }
+    [Fact]
+    public async Task When_InvalidJwtSendPayment_Expected_UnsuccessfulResponse()
+    {
+        var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, string.Empty, string.Empty, "test_memo");
+        _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
+        _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync(_validUser);
+        _mockAuthService.Setup(x => x.AuthenticateEmail(JWT, _validUser.Email)).Returns(Result<bool, CustomError>.Success(true));
+        _mockBlockchainService.Setup(x => x.SendPayment(_validUser.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), string.Empty, string.Empty, "test_memo")).ReturnsAsync(Result<bool, CustomError>.Failure(CustomError.Unauthorized()));
 
-        [Fact]
-        public async Task When_InvalidJwtSendPayment_Expected_UnsuccessfulResponse()
-        {
-            var sendPaymentDto = new SendPaymentDto(_validUser.PublicKey, 10, string.Empty, string.Empty, "test_memo");
-            _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
-            _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync(_validUser);
-            _mockAuthService.Setup(x => x.AuthenticateEmail(JWT, _validUser.Email)).Returns(Result<bool, CustomError>.Success(true));
-            _mockBlockchainService.Setup(x => x.SendPayment(_validUser.SecretKey, sendPaymentDto.DestinationPublicKey, sendPaymentDto.Amount.ToString(), string.Empty, string.Empty, "test_memo")).ReturnsAsync(Result<bool, CustomError>.Failure(CustomError.Unauthorized()));
+        var result = await _sut.SendPayment(sendPaymentDto, JWT);
 
-            var result = await _sut.SendPayment(sendPaymentDto, JWT);
+        Assert.True(!result.IsSuccess);
+    }
 
-            Assert.True(!result.IsSuccess);
-        }
-
-        [Fact]
-        public async Task When_ValidGetTransaction_Expected_PaginatedPayments()
-        {
-            BlockchainPayment[] blockchainPayments =
-            [
-                new BlockchainPayment
-                {
-                    Id = "1",
-                    From = "GBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA",
-                    To = "SBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA",
-                    Amount = "10",
-                    Asset = "XLM",
-                    CreatedAt = DateTime.Now.ToString(),
-                    WasSuccessful = true
-                }
-            ];
-
-            var pageNumber = 1;
-            var pageSize = 1;
-            _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
-            _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync(_validUser);
-            _mockAuthService.Setup(x => x.AuthenticateEmail(JWT, _validUser.Email)).Returns(Result<bool, CustomError>.Success(true));
-            _mockBlockchainService.Setup(x => x.GetPayments(_validUser.PublicKey)).ReturnsAsync(Result<BlockchainPayment[], CustomError>.Success(blockchainPayments));
-
-            var result = await _sut.GetTransaction(JWT, pageNumber, pageSize);
-
-            Assert.True(result.Value.Payments.Count == pageSize);
-            Assert.Equal(result.Value.Payments[0], blockchainPayments[0]);
-        }
-
-        [Fact]
-        public async Task When_UnexistingUserGetTransaction_Expected_UnsuccessfulResponse()
-        {
-            var pageNumber = 1;
-            var pageSize = 1;
-            _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email)); ;
-            _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync((User)null);
-
-            var result = await _sut.GetTransaction(JWT, pageNumber, pageSize);
-
-            Assert.True(!result.IsSuccess);
-        }
-
-        [Fact]
-        public async Task When_InvalidJwtGetTransaction_Expected_UnsuccessfulResponse()
-        {
-            var pageNumber = 1;
-            var pageSize = 1;
-            _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Failure(CustomError.Unauthorized()));
-            _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync(_validUser);
-            _mockAuthService.Setup(x => x.AuthenticateEmail(JWT, _validUser.Email)).Returns(Result<bool, CustomError>.Success(true));
-
-            var result = await _sut.GetTransaction(JWT, pageNumber, pageSize);
-
-            Assert.False(result.IsSuccess);
-        }
-
-        [Fact]
-        public async Task When_ValidGetTestFunds_Expected_True()
-        {
-            _mockBlockchainService.Setup(x => x.GetTestFunds(_validUser.PublicKey)).ReturnsAsync(Result<bool, CustomError>.Success(true));
-
-            var result = await _sut.GetTestFunds(_validUser.PublicKey);
-
-            Assert.True(result.Value);
-        }
-
-        [Fact]
-        public async Task When_ValidGetBalances_Expected_Balances()
-        {
-            var getBalancesDto = new GetBalancesDto()
+    [Fact]
+    public async Task When_ValidGetTransaction_Expected_PaginatedPayments()
+    {
+        BlockchainPayment[] blockchainPayments =
+        [
+            new BlockchainPayment
             {
-                PublicKey = _validUser.PublicKey,
-                FilterZeroBalances = true,
-                PageNumber = 1,
-                PageSize = 1
-            };
+                Id = "1",
+                From = "GBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA",
+                To = "SBXBDKPGYO74VVO64A7PBIHV7XN4QH4PJIRBSQT4OVE4U7JYY345PQMA",
+                Amount = "10",
+                Asset = "XLM",
+                CreatedAt = DateTime.Now.ToString(),
+                WasSuccessful = true
+            }
+        ];
 
-            List<AccountBalances> accountBalances = new()
-            {
-                new AccountBalances
-                {
-                    Asset = "XLM",
-                    Amount = "10"
-                }
-            };
+        var pageNumber = 1;
+        var pageSize = 1;
+        _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
+        _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync(_validUser);
+        _mockAuthService.Setup(x => x.AuthenticateEmail(JWT, _validUser.Email)).Returns(Result<bool, CustomError>.Success(true));
+        _mockBlockchainService.Setup(x => x.GetPayments(_validUser.PublicKey)).ReturnsAsync(Result<BlockchainPayment[], CustomError>.Success(blockchainPayments));
 
-            _mockBlockchainService.Setup(x => x.GetBalances(getBalancesDto.PublicKey)).ReturnsAsync(Result<List<AccountBalances>, CustomError>.Success(accountBalances));
+        var result = await _sut.GetTransaction(JWT, pageNumber, pageSize);
 
-            var result = await _sut.GetBalances(getBalancesDto);
+        Assert.True(result.Value.Payments.Count == pageSize);
+        Assert.Equal(result.Value.Payments[0], blockchainPayments[0]);
+    }
 
-            Assert.True(result.Value.Balances.Count == accountBalances.Count);
-            Assert.Equal(result.Value.Balances[0], accountBalances[0]);
-            Assert.True(result.Value.TotalPages == 1);
-        }
+    [Fact]
+    public async Task When_UnexistingUserGetTransaction_Expected_UnsuccessfulResponse()
+    {
+        var pageNumber = 1;
+        var pageSize = 1;
+        _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Success(_validUser.Email));
+        _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync((User?)null);
 
-        [Fact]
-        public async Task When_InvalidGetBalances_Expected_UnsuccessfulResponse()
+        var result = await _sut.GetTransaction(JWT, pageNumber, pageSize);
+
+        Assert.True(!result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task When_InvalidJwtGetTransaction_Expected_UnsuccessfulResponse()
+    {
+        var pageNumber = 1;
+        var pageSize = 1;
+        _mockJwtService.Setup(x => x.DecodeToken(JWT)).Returns(Result<string, CustomError>.Failure(CustomError.Unauthorized()));
+        _mockUnitOfWork.Setup(x => x.User.GetBy(nameof(User.Email), _validUser.Email)).ReturnsAsync(_validUser);
+        _mockAuthService.Setup(x => x.AuthenticateEmail(JWT, _validUser.Email)).Returns(Result<bool, CustomError>.Success(true));
+
+        var result = await _sut.GetTransaction(JWT, pageNumber, pageSize);
+
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task When_ValidGetTestFunds_Expected_True()
+    {
+        _mockBlockchainService.Setup(x => x.GetTestFunds(_validUser.PublicKey)).ReturnsAsync(Result<bool, CustomError>.Success(true));
+
+        var result = await _sut.GetTestFunds(_validUser.PublicKey);
+
+        Assert.True(result.Value);
+    }
+
+    [Fact]
+    public async Task When_ValidGetBalances_Expected_Balances()
+    {
+        var getBalancesDto = new GetBalancesDto()
         {
-            var getBalancesDto = new GetBalancesDto()
+            PublicKey = _validUser.PublicKey,
+            FilterZeroBalances = true,
+            PageNumber = 1,
+            PageSize = 1
+        };
+
+        List<AccountBalances> accountBalances = new()
+        {
+            new AccountBalances
             {
-                PublicKey = _validUser.PublicKey,
-                FilterZeroBalances = true,
-                PageNumber = 1,
-                PageSize = 1
-            };
+                Asset = "XLM",
+                Amount = "10"
+            }
+        };
 
-            _mockBlockchainService.Setup(x => x.GetBalances(getBalancesDto.PublicKey)).ReturnsAsync(Result<List<AccountBalances>, CustomError>.Failure(CustomError.ExternalServiceError()));
+        _mockBlockchainService.Setup(x => x.GetBalances(getBalancesDto.PublicKey)).ReturnsAsync(Result<List<AccountBalances>, CustomError>.Success(accountBalances));
 
-            var result = await _sut.GetBalances(getBalancesDto);
+        var result = await _sut.GetBalances(getBalancesDto);
 
-            Assert.True(!result.IsSuccess);
-        }
+        Assert.True(result.Value.Balances.Count == accountBalances.Count);
+        Assert.Equal(result.Value.Balances[0], accountBalances[0]);
+        Assert.True(result.Value.TotalPages == 1);
+    }
+
+    [Fact]
+    public async Task When_InvalidGetBalances_Expected_UnsuccessfulResponse()
+    {
+        var getBalancesDto = new GetBalancesDto()
+        {
+            PublicKey = _validUser.PublicKey,
+            FilterZeroBalances = true,
+            PageNumber = 1,
+            PageSize = 1
+        };
+
+        _mockBlockchainService.Setup(x => x.GetBalances(getBalancesDto.PublicKey)).ReturnsAsync(Result<List<AccountBalances>, CustomError>.Failure(CustomError.ExternalServiceError()));
+
+        var result = await _sut.GetBalances(getBalancesDto);
+
+        Assert.True(!result.IsSuccess);
     }
 }

--- a/StellarWallet.UnitTest/StellarWallet.UnitTest.csproj
+++ b/StellarWallet.UnitTest/StellarWallet.UnitTest.csproj
@@ -15,6 +15,10 @@
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.3.0.106239">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -23,6 +27,10 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\.editorconfig" />
   </ItemGroup>
 
 </Project>

--- a/StellarWallet.WebApi/Controllers/AuthController.cs
+++ b/StellarWallet.WebApi/Controllers/AuthController.cs
@@ -4,65 +4,64 @@ using Microsoft.AspNetCore.Mvc;
 using StellarWallet.Application.Dtos.Requests;
 using StellarWallet.Application.Interfaces;
 
-namespace StellarWallet.WebApi.Controllers
+namespace StellarWallet.WebApi.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class AuthController(IAuthService authService) : ControllerBase
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class AuthController(IAuthService authService) : ControllerBase
+    private readonly IAuthService _authService = authService;
+
+    [HttpPost("Login")]
+    public async Task<IActionResult> Login([FromBody] LoginDto loginDto)
     {
-        private readonly IAuthService _authService = authService;
-
-        [HttpPost("Login")]
-        public async Task<IActionResult> Login([FromBody] LoginDto loginDto)
+        if (!ModelState.IsValid)
         {
-            if (!ModelState.IsValid)
-            {
-                return BadRequest(ModelState);
-            }
-
-            try
-            {
-                var result = await _authService.Login(loginDto);
-
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result);
-                }
-
-                return Ok(result);
-            }
-            catch (Exception e)
-            {
-                return StatusCode(StatusCodes.Status500InternalServerError, e.Message);
-            }
+            return BadRequest(ModelState);
         }
 
-        [Authorize]
-        [HttpGet("UserToken")]
-        public async Task<IActionResult> UserToken()
+        try
         {
+            var result = await _authService.Login(loginDto);
 
-            try
+            if (!result.IsSuccess)
             {
-                string? jwt = await HttpContext.GetTokenAsync("access_token");
-                if (jwt is null)
-                {
-                    return Unauthorized();
-                }
-
-                var result = await _authService.AuthenticateToken(jwt);
-
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result);
-                }
-
-                return Ok(result);
+                return StatusCode(result.Error.Code, result);
             }
-            catch (Exception e)
+
+            return Ok(result);
+        }
+        catch (Exception e)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, e.Message);
+        }
+    }
+
+    [Authorize]
+    [HttpGet("UserToken")]
+    public async Task<IActionResult> UserToken()
+    {
+
+        try
+        {
+            var jwt = await HttpContext.GetTokenAsync("access_token");
+            if (jwt is null)
             {
-                return StatusCode(StatusCodes.Status500InternalServerError, e.Message);
+                return Unauthorized();
             }
+
+            var result = await _authService.AuthenticateToken(jwt);
+
+            if (!result.IsSuccess)
+            {
+                return StatusCode(result.Error.Code, result);
+            }
+
+            return Ok(result);
+        }
+        catch (Exception e)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, e.Message);
         }
     }
 }

--- a/StellarWallet.WebApi/Controllers/TransactionController.cs
+++ b/StellarWallet.WebApi/Controllers/TransactionController.cs
@@ -4,101 +4,28 @@ using Microsoft.AspNetCore.Mvc;
 using StellarWallet.Application.Dtos.Requests;
 using StellarWallet.Application.Interfaces;
 
-namespace StellarWallet.WebApi.Controllers
+namespace StellarWallet.WebApi.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("[controller]")]
+public class TransactionController(ITransactionService transactionService) : ControllerBase
 {
-    [ApiController]
-    [Authorize]
-    [Route("[controller]")]
-    public class TransactionController(ITransactionService transactionService) : ControllerBase
+    private readonly ITransactionService _transactionService = transactionService;
+    private readonly string _accessToken = "access_token";
+
+    [HttpPost("AccountCreation")]
+    public async Task<IActionResult> CreateAccount()
     {
-        private readonly ITransactionService _transactionService = transactionService;
-        private readonly string _accessToken = "access_token";
-
-        [HttpPost("AccountCreation")]
-        public async Task<IActionResult> CreateAccount()
+        try
         {
-            try
-            {
-                string? jwt = await HttpContext.GetTokenAsync(_accessToken);
-                if (jwt is null)
-                {
-                    return Unauthorized();
-                }
-
-                var result = await _transactionService.CreateAccount(jwt);
-
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result);
-                }
-
-                return Ok(result);
-            }
-            catch (Exception e)
-            {
-                return StatusCode(StatusCodes.Status500InternalServerError, e.Message);
-            }
-        }
-
-        [HttpPost("Payment")]
-        public async Task<IActionResult> SendPayment([FromBody] SendPaymentDto sendPaymentDto)
-        {
-            try
-            {
-                string? jwt = await HttpContext.GetTokenAsync(_accessToken);
-                if (jwt is null)
-                {
-                    return Unauthorized();
-                }
-
-                var paymentResult = await _transactionService.SendPayment(sendPaymentDto, jwt);
-
-                if (!paymentResult.IsSuccess)
-                {
-                    return StatusCode(paymentResult.Error.Code, paymentResult.Error.Message);
-                }
-                return Ok();
-            }
-            catch
-            {
-                return StatusCode(StatusCodes.Status500InternalServerError, "There was an error processing the payment.");
-            }
-        }
-
-        [HttpGet("Payment")]
-        public async Task<IActionResult> GetPayments([FromQuery] int pageNumber, int pageSize)
-        {
-            try
-            {
-                string? jwt = await HttpContext.GetTokenAsync(_accessToken);
-                if (jwt is null)
-                {
-                    return Unauthorized();
-                }
-
-                var result = await _transactionService.GetTransaction(jwt, pageNumber, pageSize);
-
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result);
-                }
-
-                return Ok(result);
-            }
-            catch (Exception e)
-            {
-                return StatusCode(StatusCodes.Status500InternalServerError, e.Message);
-            }
-        }
-
-        [HttpPost("TestFund")]
-        public async Task<IActionResult> GetTestFunds([FromBody] GetTestFundsDto getTestFundsDto)
-        {
-            string? jwt = await HttpContext.GetTokenAsync(_accessToken);
+            var jwt = await HttpContext.GetTokenAsync(_accessToken);
             if (jwt is null)
-            { return Unauthorized(); }
+            {
+                return Unauthorized();
+            }
 
-            var result = await _transactionService.GetTestFunds(getTestFundsDto.PublicKey);
+            var result = await _transactionService.CreateAccount(jwt);
 
             if (!result.IsSuccess)
             {
@@ -107,31 +34,103 @@ namespace StellarWallet.WebApi.Controllers
 
             return Ok(result);
         }
-
-        [HttpGet("Balance")]
-        public async Task<IActionResult> GetBalances([FromQuery] GetBalancesDto getBalancesDto)
+        catch (Exception e)
         {
-            string? jwt = await HttpContext.GetTokenAsync(_accessToken);
+            return StatusCode(StatusCodes.Status500InternalServerError, e.Message);
+        }
+    }
+
+    [HttpPost("Payment")]
+    public async Task<IActionResult> SendPayment([FromBody] SendPaymentDto sendPaymentDto)
+    {
+        try
+        {
+            var jwt = await HttpContext.GetTokenAsync(_accessToken);
             if (jwt is null)
             {
                 return Unauthorized();
             }
 
-            try
-            {
-                var result = await _transactionService.GetBalances(getBalancesDto);
+            var paymentResult = await _transactionService.SendPayment(sendPaymentDto, jwt);
 
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result);
-                }
-
-                return Ok(result);
-            }
-            catch (Exception e)
+            if (!paymentResult.IsSuccess)
             {
-                return StatusCode(StatusCodes.Status500InternalServerError, e.Message);
+                return StatusCode(paymentResult.Error.Code, paymentResult.Error.Message);
             }
+            return Ok();
+        }
+        catch
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, "There was an error processing the payment.");
+        }
+    }
+
+    [HttpGet("Payment")]
+    public async Task<IActionResult> GetPayments([FromQuery] int pageNumber, int pageSize)
+    {
+        try
+        {
+            var jwt = await HttpContext.GetTokenAsync(_accessToken);
+            if (jwt is null)
+            {
+                return Unauthorized();
+            }
+
+            var result = await _transactionService.GetTransaction(jwt, pageNumber, pageSize);
+
+            if (!result.IsSuccess)
+            {
+                return StatusCode(result.Error.Code, result);
+            }
+
+            return Ok(result);
+        }
+        catch (Exception e)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, e.Message);
+        }
+    }
+
+    [HttpPost("TestFund")]
+    public async Task<IActionResult> GetTestFunds([FromBody] GetTestFundsDto getTestFundsDto)
+    {
+        var jwt = await HttpContext.GetTokenAsync(_accessToken);
+        if (jwt is null)
+        { return Unauthorized(); }
+
+        var result = await _transactionService.GetTestFunds(getTestFundsDto.PublicKey);
+
+        if (!result.IsSuccess)
+        {
+            return StatusCode(result.Error.Code, result);
+        }
+
+        return Ok(result);
+    }
+
+    [HttpGet("Balance")]
+    public async Task<IActionResult> GetBalances([FromQuery] GetBalancesDto getBalancesDto)
+    {
+        var jwt = await HttpContext.GetTokenAsync(_accessToken);
+        if (jwt is null)
+        {
+            return Unauthorized();
+        }
+
+        try
+        {
+            var result = await _transactionService.GetBalances(getBalancesDto);
+
+            if (!result.IsSuccess)
+            {
+                return StatusCode(result.Error.Code, result);
+            }
+
+            return Ok(result);
+        }
+        catch (Exception e)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, e.Message);
         }
     }
 }

--- a/StellarWallet.WebApi/Controllers/UserContactController.cs
+++ b/StellarWallet.WebApi/Controllers/UserContactController.cs
@@ -4,105 +4,104 @@ using Microsoft.AspNetCore.Mvc;
 using StellarWallet.Application.Dtos.Requests;
 using StellarWallet.Application.Interfaces;
 
-namespace StellarWallet.WebApi.Controllers
+namespace StellarWallet.WebApi.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("[controller]")]
+public class UserContactController(IUserContactService userContactService) : ControllerBase
 {
-    [ApiController]
-    [Authorize]
-    [Route("[controller]")]
-    public class UserContactController(IUserContactService userContactService) : ControllerBase
+    private readonly IUserContactService _userContactService = userContactService;
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetAll(int id)
     {
-        private readonly IUserContactService _userContactService = userContactService;
-
-        [HttpGet("{id}")]
-        public async Task<IActionResult> GetAll(int id)
+        try
         {
-            try
+            var jwt = await HttpContext.GetTokenAsync("access_token");
+            if (jwt is null)
             {
-                string? jwt = await HttpContext.GetTokenAsync("access_token");
-                if (jwt is null)
-                {
-                    return Unauthorized();
-                }
-
-                var result = await _userContactService.GetAll(id, jwt);
-
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result);
-                }
-
-                return Ok(result);
+                return Unauthorized();
             }
-            catch (Exception e)
+
+            var result = await _userContactService.GetAll(id, jwt);
+
+            if (!result.IsSuccess)
             {
-                return StatusCode(StatusCodes.Status500InternalServerError, $"Internal server error: {e.Message}");
+                return StatusCode(result.Error.Code, result);
             }
+
+            return Ok(result);
         }
-
-        [HttpDelete("{id}")]
-        public async Task<IActionResult> Delete(int id)
+        catch (Exception e)
         {
-            try
-            {
-                var result = await _userContactService.Delete(id);
-
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result);
-                }
-
-                return Ok(result);
-            }
-            catch (Exception e)
-            {
-                return StatusCode(StatusCodes.Status500InternalServerError, $"Internal server error: {e.Message}");
-            }
+            return StatusCode(StatusCodes.Status500InternalServerError, $"Internal server error: {e.Message}");
         }
+    }
 
-        [HttpPost()]
-        public async Task<IActionResult> Post(AddContactDto userContact)
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        try
         {
-            try
+            var result = await _userContactService.Delete(id);
+
+            if (!result.IsSuccess)
             {
-                string? jwt = await HttpContext.GetTokenAsync("access_token");
-                if (jwt is null)
-                {
-                    return Unauthorized();
-                }
-
-                var result = await _userContactService.Add(userContact, jwt);
-
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result);
-                }
-
-                return Ok(result);
+                return StatusCode(result.Error.Code, result);
             }
-            catch (Exception e)
-            {
-                return StatusCode(500, $"Internal server error: {e.Message}");
-            }
+
+            return Ok(result);
         }
-
-        [HttpPut()]
-        public async Task<IActionResult> Put(UpdateContactDto userContact)
+        catch (Exception e)
         {
-            try
-            {
-                var result = await _userContactService.Update(userContact);
+            return StatusCode(StatusCodes.Status500InternalServerError, $"Internal server error: {e.Message}");
+        }
+    }
 
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result);
-                }
-
-                return Ok(result);
-            }
-            catch (Exception e)
+    [HttpPost()]
+    public async Task<IActionResult> Post(AddContactDto userContact)
+    {
+        try
+        {
+            var jwt = await HttpContext.GetTokenAsync("access_token");
+            if (jwt is null)
             {
-                return StatusCode(StatusCodes.Status500InternalServerError, $"Internal server error: {e.Message}");
+                return Unauthorized();
             }
+
+            var result = await _userContactService.Add(userContact, jwt);
+
+            if (!result.IsSuccess)
+            {
+                return StatusCode(result.Error.Code, result);
+            }
+
+            return Ok(result);
+        }
+        catch (Exception e)
+        {
+            return StatusCode(500, $"Internal server error: {e.Message}");
+        }
+    }
+
+    [HttpPut()]
+    public async Task<IActionResult> Put(UpdateContactDto userContact)
+    {
+        try
+        {
+            var result = await _userContactService.Update(userContact);
+
+            if (!result.IsSuccess)
+            {
+                return StatusCode(result.Error.Code, result);
+            }
+
+            return Ok(result);
+        }
+        catch (Exception e)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, $"Internal server error: {e.Message}");
         }
     }
 }

--- a/StellarWallet.WebApi/Controllers/UserController.cs
+++ b/StellarWallet.WebApi/Controllers/UserController.cs
@@ -7,165 +7,164 @@ using StellarWallet.Application.Interfaces;
 using StellarWallet.Domain.Errors;
 using StellarWallet.Domain.Result;
 
-namespace StellarWallet.WebApi.Controllers
+namespace StellarWallet.WebApi.Controllers;
+
+
+[ApiController]
+[Route("[controller]")]
+public class UserController(IUserService userService) : ControllerBase
 {
+    private readonly IUserService _userService = userService;
 
-    [ApiController]
-    [Route("[controller]")]
-    public class UserController(IUserService userService) : ControllerBase
+    [HttpGet()]
+    [Authorize(Roles = "admin")]
+    public async Task<IActionResult> Get()
     {
-        private readonly IUserService _userService = userService;
-
-        [HttpGet()]
-        [Authorize(Roles = "admin")]
-        public async Task<IActionResult> Get()
+        try
         {
-            try
+            var result = await _userService.GetAll();
+
+            if (!result.IsSuccess)
             {
-                var result = await _userService.GetAll();
+                return StatusCode(result.Error.Code, result.Error);
+            }
 
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result.Error);
-                }
+            return Ok(result);
+        }
+        catch (Exception e)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, $"Error: {e.Message}");
+        }
+    }
 
+    [HttpGet("{id}")]
+    [Authorize]
+    public async Task<IActionResult> Get(int id)
+    {
+        try
+        {
+            var jwt = await HttpContext.GetTokenAsync("access_token");
+
+            if (jwt is null)
+            {
+                return Unauthorized();
+            }
+
+            var result = await _userService.GetById(id, jwt);
+
+            if (!result.IsSuccess)
+            {
+                return StatusCode(result.Error.Code, result.Error);
+            }
+
+            return Ok(result);
+        }
+        catch (Exception e)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, $"Error: {e.Message}");
+        }
+    }
+
+    [HttpPost()]
+    public async Task<ActionResult<Result<LoggedDto, CustomError>>> Post(UserCreationDto user)
+    {
+        try
+        {
+            var result = await _userService.Add(user);
+
+            if (result.IsSuccess)
+            {
                 return Ok(result);
             }
-            catch (Exception e)
+            else
             {
-                return StatusCode(StatusCodes.Status500InternalServerError, $"Error: {e.Message}");
+                return StatusCode(result.Error.Code, result.Error);
             }
         }
-
-        [HttpGet("{id}")]
-        [Authorize]
-        public async Task<IActionResult> Get(int id)
+        catch (Exception e)
         {
-            try
+            return StatusCode(StatusCodes.Status500InternalServerError, $"Internal server error: {e.Message}");
+        }
+    }
+
+    [HttpPut()]
+    [Authorize]
+    public async Task<IActionResult> Put(UserUpdateDto user)
+    {
+        try
+        {
+            var jwt = await HttpContext.GetTokenAsync("access_token");
+            if (jwt is null)
             {
-                string? jwt = await HttpContext.GetTokenAsync("access_token");
-
-                if (jwt is null)
-                {
-                    return Unauthorized();
-                }
-
-                var result = await _userService.GetById(id, jwt);
-
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result.Error);
-                }
-
-                return Ok(result);
+                return Unauthorized();
             }
-            catch (Exception e)
+
+            var result = await _userService.Update(user, jwt);
+            if (!result.IsSuccess)
             {
-                return StatusCode(StatusCodes.Status500InternalServerError, $"Error: {e.Message}");
+                return StatusCode(result.Error.Code, result.Error);
             }
+
+            return Ok(result);
+        }
+        catch (Exception e)
+        {
+            return StatusCode(StatusCodes.Status500InternalServerError, $"Error: {e.Message}");
         }
 
-        [HttpPost()]
-        public async Task<ActionResult<Result<LoggedDto, CustomError>>> Post(UserCreationDto user)
-        {
-            try
-            {
-                var result = await _userService.Add(user);
+    }
 
-                if (result.IsSuccess)
-                {
-                    return Ok(result);
-                }
-                else
-                {
-                    return StatusCode(result.Error.Code, result.Error);
-                }
-            }
-            catch (Exception e)
+    [HttpDelete("{id}")]
+    [Authorize]
+    public async Task<IActionResult> Delete(int id)
+    {
+        try
+        {
+            var jwt = await HttpContext.GetTokenAsync("access_token");
+            if (jwt is null)
             {
-                return StatusCode(StatusCodes.Status500InternalServerError, $"Internal server error: {e.Message}");
+                return Unauthorized();
             }
+
+            var result = await _userService.Delete(id, jwt);
+
+            if (!result.IsSuccess)
+            {
+                return StatusCode(result.Error.Code, result.Error);
+            }
+
+            return Ok(result);
         }
-
-        [HttpPut()]
-        [Authorize]
-        public async Task<IActionResult> Put(UserUpdateDto user)
+        catch (Exception e)
         {
-            try
-            {
-                string? jwt = await HttpContext.GetTokenAsync("access_token");
-                if (jwt is null)
-                {
-                    return Unauthorized();
-                }
-
-                var result = await _userService.Update(user, jwt);
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result.Error);
-                }
-
-                return Ok(result);
-            }
-            catch (Exception e)
-            {
-                return StatusCode(StatusCodes.Status500InternalServerError, $"Error: {e.Message}");
-            }
-
+            return StatusCode(StatusCodes.Status500InternalServerError, $"Error: {e.Message}");
         }
+    }
 
-        [HttpDelete("{id}")]
-        [Authorize]
-        public async Task<IActionResult> Delete(int id)
+    [HttpPost("Wallet")]
+    [Authorize]
+    public async Task<IActionResult> AddWallet([FromBody] AddWalletDto wallet)
+    {
+        try
         {
-            try
+            var jwt = await HttpContext.GetTokenAsync("access_token");
+            if (jwt is null)
             {
-                string? jwt = await HttpContext.GetTokenAsync("access_token");
-                if (jwt is null)
-                {
-                    return Unauthorized();
-                }
-
-                var result = await _userService.Delete(id, jwt);
-
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result.Error);
-                }
-
-                return Ok(result);
+                return Unauthorized();
             }
-            catch (Exception e)
+
+            var result = await _userService.AddWallet(wallet, jwt);
+
+            if (!result.IsSuccess)
             {
-                return StatusCode(StatusCodes.Status500InternalServerError, $"Error: {e.Message}");
+                return StatusCode(result.Error.Code, result.Error);
             }
+
+            return Ok(result);
         }
-
-        [HttpPost("Wallet")]
-        [Authorize]
-        public async Task<IActionResult> AddWallet([FromBody] AddWalletDto wallet)
+        catch (Exception e)
         {
-            try
-            {
-                string? jwt = await HttpContext.GetTokenAsync("access_token");
-                if (jwt is null)
-                {
-                    return Unauthorized();
-                }
-
-                var result = await _userService.AddWallet(wallet, jwt);
-
-                if (!result.IsSuccess)
-                {
-                    return StatusCode(result.Error.Code, result.Error);
-                }
-
-                return Ok(result);
-            }
-            catch (Exception e)
-            {
-                return StatusCode(StatusCodes.Status500InternalServerError, $"Internal server error: {e.Message}");
-            }
+            return StatusCode(StatusCodes.Status500InternalServerError, $"Internal server error: {e.Message}");
         }
     }
 }

--- a/StellarWallet.WebApi/Program.cs
+++ b/StellarWallet.WebApi/Program.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
@@ -6,106 +8,112 @@ using StellarWallet.Application.Mappers;
 using StellarWallet.Application.Services;
 using StellarWallet.Domain.Interfaces.Persistence;
 using StellarWallet.Domain.Interfaces.Services;
-using StellarWallet.Infrastructure.Services;
-using StellarWallet.Infrastructure.Repositories;
-using System.Security.Claims;
-using System.Text;
 using StellarWallet.Infrastructure;
+using StellarWallet.Infrastructure.Repositories;
+using StellarWallet.Infrastructure.Services;
 
-string environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "test";
-
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Configuration.AddJsonFile($"appsettings.{environmentName}.json");
-
-// Add services to the container.
-
-// Add authentication services
-builder.Services.AddAuthentication(config =>
+internal class Program
 {
-    config.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-    config.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-}).AddJwtBearer(config =>
-{
-    config.RequireHttpsMetadata = false;
-    config.SaveToken = true;
-    config.TokenValidationParameters = new TokenValidationParameters
+    private static async Task Main(string[] args)
     {
-        ValidateIssuerSigningKey = true,
-        ValidateIssuer = true,
-        ValidateAudience = true,
-        ValidateLifetime = true,
+        var environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "test";
 
-        ValidAudience = builder.Configuration["Jwt:Audience"],
-        ValidIssuer = builder.Configuration["Jwt:Issuer"],
-        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"] ?? throw new InvalidOperationException("JWT Key is not configured."))),
-    };
-});
+        var builder = WebApplication.CreateBuilder(args);
 
-var connectionString = builder.Configuration.GetConnectionString("StellarWalletDatabase") ?? throw new InvalidOperationException("Undefined connection string");
+        builder.Configuration.AddJsonFile($"appsettings.{environmentName}.json");
 
-// Add roles authorization
-builder.Services.AddAuthorizationBuilder()
-                              .AddPolicy("Admin", policy => policy.RequireClaim(ClaimTypes.Role, "admin"))
-                              .AddPolicy("User", policy => policy.RequireClaim(ClaimTypes.Role, "user"));
+        // Add services to the container.
 
-builder.Services.AddControllers();
-builder.Services.AddDbContext<DatabaseContext>(options => options.UseSqlServer(connectionString, b => b.MigrationsAssembly("StellarWallet.Infrastructure"))); // Add DatabaseContext
-builder.Services.AddScoped<IUserRepository, UserRepository>(); // Add UserRepository
-builder.Services.AddScoped<IUserService, UserService>(); // Add UserService
-builder.Services.AddScoped<IBlockchainService, StellarService>(); // Add BlockchainService
-builder.Services.AddScoped<ITransactionService, TransactionService>(); // Add TransactionService
-builder.Services.AddScoped<IAuthService, AuthService>(); // Add AuthService
-builder.Services.AddScoped<IJwtService, JwtService>(); // Add JwtService
-builder.Services.AddScoped<IEncryptionService, EncryptionService>(); // Add EncryptionService
-builder.Services.AddScoped<IUserContactRepository, UserContactRepository>(); // Add UserContactRepository
-builder.Services.AddScoped<IUserContactService, UserContactService>(); // Add UserContactService
-builder.Services.AddScoped<IBlockchainAccountRepository, BlockchainAccountRepository>(); // Add BlockchainAccountRepository
-builder.Services.AddAutoMapper(typeof(AutoMapperProfile)); // Add AutoMapper
-builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
+        // Add authentication services
+        builder.Services.AddAuthentication(config =>
+        {
+            config.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            config.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        }).AddJwtBearer(config =>
+        {
+            config.RequireHttpsMetadata = false;
+            config.SaveToken = true;
+            config.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuerSigningKey = true,
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
 
-builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+                ValidAudience = builder.Configuration["Jwt:Audience"],
+                ValidIssuer = builder.Configuration["Jwt:Issuer"],
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"] ?? throw new InvalidOperationException("JWT Key is not configured."))),
+            };
+        });
 
-var corsPolicyName = "AllowClient";
+        var connectionString = builder.Configuration.GetConnectionString("StellarWalletDatabase") ?? throw new InvalidOperationException("Undefined connection string");
 
-builder.Services.AddCors(options =>
-{
-    var origins = builder.Configuration.GetValue<string>("AllowedHosts") ?? throw new InvalidOperationException("Allowed hosts are not configured.");
-    options.AddPolicy(corsPolicyName, builder =>
-    {
-        builder.WithOrigins(origins)
-            .AllowAnyMethod()
-            .AllowAnyHeader();
-    });
-});
+        // Add roles authorization
+        builder.Services.AddAuthorizationBuilder()
+                                      .AddPolicy("Admin", policy => policy.RequireClaim(ClaimTypes.Role, "admin"))
+                                      .AddPolicy("User", policy => policy.RequireClaim(ClaimTypes.Role, "user"));
 
-var app = builder.Build();
+        builder.Services.AddControllers();
+        builder.Services.AddDbContext<DatabaseContext>(options => options.UseSqlServer(connectionString, b => b.MigrationsAssembly("StellarWallet.Infrastructure"))); // Add DatabaseContext
+        builder.Services.AddScoped<IUserRepository, UserRepository>(); // Add UserRepository
+        builder.Services.AddScoped<IUserService, UserService>(); // Add UserService
+        builder.Services.AddScoped<IBlockchainService, StellarService>(); // Add BlockchainService
+        builder.Services.AddScoped<ITransactionService, TransactionService>(); // Add TransactionService
+        builder.Services.AddScoped<IAuthService, AuthService>(); // Add AuthService
+        builder.Services.AddScoped<IJwtService, JwtService>(); // Add JwtService
+        builder.Services.AddScoped<IEncryptionService, EncryptionService>(); // Add EncryptionService
+        builder.Services.AddScoped<IUserContactRepository, UserContactRepository>(); // Add UserContactRepository
+        builder.Services.AddScoped<IUserContactService, UserContactService>(); // Add UserContactService
+        builder.Services.AddScoped<IBlockchainAccountRepository, BlockchainAccountRepository>(); // Add BlockchainAccountRepository
+        builder.Services.AddAutoMapper(typeof(AutoMapperProfile)); // Add AutoMapper
+        builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 
-app.UseCors(corsPolicyName);
+        builder.Services.AddControllers();
+        // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+        builder.Services.AddEndpointsApiExplorer();
+        builder.Services.AddSwaggerGen();
 
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+        var corsPolicyName = "AllowClient";
 
-app.UseHttpsRedirection();
+        builder.Services.AddCors(options =>
+        {
+            var origins = builder.Configuration.GetValue<string>("AllowedHosts") ?? throw new InvalidOperationException("Allowed hosts are not configured.");
+            options.AddPolicy(corsPolicyName, builder =>
+            {
+                builder.WithOrigins(origins)
+                    .AllowAnyMethod()
+                    .AllowAnyHeader();
+            });
+        });
 
-if (app.Environment.EnvironmentName != "test")
-    using (var scope = app.Services.CreateScope())
-    {
-        var db = scope.ServiceProvider.GetRequiredService<DatabaseContext>();
-        await db.Database.MigrateAsync();
+        var app = builder.Build();
+
+        app.UseCors(corsPolicyName);
+
+        // Configure the HTTP request pipeline.
+        if (app.Environment.IsDevelopment())
+        {
+            app.UseSwagger();
+            app.UseSwaggerUI();
+        }
+
+        app.UseHttpsRedirection();
+
+        if (app.Environment.EnvironmentName != "test")
+        {
+            using (var scope = app.Services.CreateScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<DatabaseContext>();
+                await db.Database.MigrateAsync();
+            }
+        }
+
+        app.UseAuthentication();
+
+        app.UseAuthorization();
+
+        app.MapControllers();
+
+        await app.RunAsync();
     }
-
-app.UseAuthentication();
-
-app.UseAuthorization();
-
-app.MapControllers();
-
-await app.RunAsync();
+}

--- a/StellarWallet.WebApi/StellarWallet.WebApi.csproj
+++ b/StellarWallet.WebApi/StellarWallet.WebApi.csproj
@@ -12,6 +12,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.3.0.106239">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -37,5 +41,9 @@
   <ItemGroup>
     <InternalsVisibleTo Include="StellarWallet.IntegrationTest" />
 	</ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\.editorconfig" />
+  </ItemGroup>
   
 </Project>


### PR DESCRIPTION
# Summary

- Add extensive configuration to enforce coding conventions, including severity settings for various rules, indentation and spacing - Replace `dotnet-format` with `csharpier` and updated the version of `husky`.
- Simplify the `pre-commit` hook to run the formatter and linter using `Husky`.
- Cleane up the `pre-push` hook script to remove unnecessary comments.
- Update tasks to use `csharpier` for formatting and added a task to run `SonarAnalyzer`.
- Format and refactor base code based on the `.editorconfig` rules.

# Details

- Improve code formatting, enforce coding standards.
- Update Husky configurations for pre-commit and pre-push hooks.